### PR TITLE
Update sitebase.jinja2

### DIFF
--- a/microsetta_interface/templates/home.jinja2
+++ b/microsetta_interface/templates/home.jinja2
@@ -24,23 +24,23 @@
         {% endif %}
     </div>
     {% else %}
-    <p>
-        It appears that your email has not yet been verified.
-        Please check your email account (and spam folder) for a verification email
-        from "The Microsetta Initiative" and follow its instructions.
-        This email will come from our authentication service AuthRocket,
-        and use the email address "noreply@loginrocket.com".
+  <p>
+        To continue: Check your email account to obtain your confirmation email and link, which was sent to confirm your account.
+        This email will come from our authentication service, AuthRocket, under the email address "noreply@loginrocket.com".
     </p>
     <p>
-        If you cannot locate the original verification email, have it resent by
-        clicking <a href = "{{ authrocket_url }}/profile">here</a> to view your AuthRocket profile and then
-        clicking the "resend verification email" link.
+        If you cannot locate the original confirmation email, have it resent by
+        clicking the button below to view your AuthRocket profile, and then
+        clicking the "resend verification email" link next to your email address.
     </p>
     <p>
-        <button class = "btn btn-primary" onclick="window.location.replace('{{authrocket_url}}/login?redirect_uri={{endpoint}}/authrocket_callback');">
-            Refresh
-        </button>
+        <a href = "{{ authrocket_url }}/profile"><button class = "btn btn-primary">
+            View AuthRocket Profile
+        </button></a>
     </p>
+    
+    <p>If you do not receive this email within a few minutes and have checked your spam/junk mail folders, please contact us at
+    <a href="mailto:microsetta@ucsd.edu">microsetta@ucsd.edu</a>.
     {% endif %}
 {% else %}
     You are not logged in. Please click to either: <br/>

--- a/microsetta_interface/templates/signup_intermediate.jinja2
+++ b/microsetta_interface/templates/signup_intermediate.jinja2
@@ -20,8 +20,9 @@
     <img src="/static/img/old_registration_no_password.jpg" class="resize"/><br/>
     Some cards may also contain a 'Password:' field, which we currently DO NOT require, so please disregard it.<br/>
     <img src="/static/img/old_registration_password.jpg" class="resize"/>
+    </p>
     
        <p>Continue to Sign Up: <br/>
-       <a href="{{authrocket_url}}/signup?redirect_uri={{endpoint}}/authrocket_callback"><button class="btn btn-primary">Sign Up</button></a>. </p>
+       <a href="{{authrocket_url}}/signup?redirect_uri={{endpoint}}/authrocket_callback"><button class="btn btn-primary">Sign Up</button></a></p>
 </div>
 {% endblock %}

--- a/microsetta_interface/templates/signup_intermediate.jinja2
+++ b/microsetta_interface/templates/signup_intermediate.jinja2
@@ -3,20 +3,25 @@
 {% set show_breadcrumbs = True %}
 {% set show_logout = False %}
 {% block content %}
-<h2>Sign up help and more information</h2>
 <div class="list-group">
-    <p>This page contains more information about the sign up process.</p>
-    <p>When you are ready to proceed, please click: <a href="{{authrocket_url}}/signup?redirect_uri={{endpoint}}/authrocket_callback">Sign Up</a>. 
+    <p>Before signing up, please read the following information to assist you during this process.</p>
+
 </div>
-<h2>Email verification</h2>
+<h4><u>How to create a "Login"</u></h4>
 <div class="list-group">
-    <p>In order to create a login, you will need to enter a valid email address and a password of your choice. After entering this information, you will be sent a verification email so the system to ensure the email was recorded correctly. It should only take a few minutes for a verification email to arrive. If it doesn't show up, please check spam or junk mail. If a verification email is not there, please email us at <a href="mailto:microsetta@ucsd.edu">microsetta@ucsd.edu</a> and we will resolve the issue.<p>
+    <p>To create your login, you will need a valid email address and a password of your choice. After entering this information, you will be sent a link to the email provided to
+       verify we have the correct information. If you do not receive this email within a few minutes and have checked your spam/junk mail folders, please contact us at <a href="mailto:microsetta@ucsd.edu">microsetta@ucsd.edu</a>, 
+       and we will resolve the issue.<p>
 </div>
-<h2>Registration card</h2>
+<h4><u>Registration Card</u></h4>
 <div class="list-group">
-    Participant kits contain a registration card that looks like the following. You do not need this card to create a login, however you will need this card afterward in order to create your account.
-    <img src="/static/img/old_registration_no_password.jpg" class="resize"/>
-    If your registration card contains a "Password:" field as shown in the following image, please disregard it.
+    <p>The kit you have received contains a registration card (found inside the kit's plastic sleeve for Step #2). On this card, you will find
+    your Kit ID, which you will need to create your account and to later connect your samples to your profile.<br/>
+    <img src="/static/img/old_registration_no_password.jpg" class="resize"/><br/>
+    Some cards may also contain a 'Password:' field, which we currently DO NOT require, so please disregard it.<br/>
     <img src="/static/img/old_registration_password.jpg" class="resize"/>
+    
+       <p>Continue to Sign Up: <br/>
+       <a href="{{authrocket_url}}/signup?redirect_uri={{endpoint}}/authrocket_callback"><button class="btn btn-primary">Sign Up</button></a>. </p>
 </div>
 {% endblock %}

--- a/microsetta_interface/templates/sitebase.jinja2
+++ b/microsetta_interface/templates/sitebase.jinja2
@@ -54,6 +54,9 @@
     <div class="content">
 
     {% if show_breadcrumbs %}
+        <nav class="navbar navbar-expand-lg navbar-light" style="background-color:#e9ecef;">
+      <div class="collapse navbar-collapse" id="navbarText">
+    <ul class="navbar-nav mr-auto">
         <nav aria-label="breadcrumb">
           <ol class="breadcrumb">
             {% if is_home %}
@@ -64,16 +67,19 @@
             {%block breadcrumb%}
             {%endblock%}
           </ol>
-        </nav>
+        </nav></ul>
     {% endif %}
 
-        <!-- Vue Form Generator references a container named "app" -->
-        <div class="container" id="app">
         {% if show_logout %}
             <div>
                 <a href="{{authrocket_url}}/logout?redirect_uri={{endpoint}}/logout">Log Out</a>
             </div>
         {% endif %}
+        
+        </div></nav>
+        
+        <!-- Vue Form Generator references a container named "app" -->
+        <div class="container" id="app">
 {%block content%}
 {%endblock%}
         </div>

--- a/microsetta_interface/templates/sitebase.jinja2
+++ b/microsetta_interface/templates/sitebase.jinja2
@@ -92,8 +92,9 @@
         <hr>
           <p>We will periodically update this site with minor revisions; we
           apologize if you encounter any temporary inconveniences.</p>
+          
+           <p>
         {% if not disable_faq %}
-        <p>
             Questions?  Check out our <a href="/view_faq" target="_blank">FAQ</a>!</br>
         {% endif %}
             Stuck?  Please contact

--- a/microsetta_interface/templates/sitebase.jinja2
+++ b/microsetta_interface/templates/sitebase.jinja2
@@ -88,17 +88,15 @@
           apologize if you encounter any temporary inconveniences.</p>
         {% if not disable_faq %}
         <p>
-            Questions?  Check out our <a href="/view_faq" target="_blank">FAQ</a>!
-        </p>
+            Questions?  Check out our <a href="/view_faq" target="_blank">FAQ</a>!</br>
         {% endif %}
-        <p>
             Stuck?  Please contact
             <a href="mailto:microsetta@ucsd.edu">microsetta@ucsd.edu</a>
             for help.
             <br/><br/>
             <a href="https://microsetta.ucsd.edu" title="microsetta.ucsd.edu">Return to microsetta.ucsd.edu</a>
         </p>
-    </div>
+    </div> 
     {% endif %}
 </body>
 </html>

--- a/microsetta_interface/templates/sitebase.jinja2
+++ b/microsetta_interface/templates/sitebase.jinja2
@@ -40,7 +40,6 @@
         <img src="/static/img/logo-co.png" class="resize"/>
         <br />
         <br />
-        Return to microsetta.ucsd.edu
     </a>
     <br />
     <br />
@@ -85,17 +84,19 @@
     <div>
         <br />
         <hr>
+          <p>We will periodically update this site with minor revisions; we
+          apologize if you encounter any temporary inconveniences.</p>
         {% if not disable_faq %}
         <p>
-            Questions?  Check our <a href="/view_faq" target="_blank">FAQ</a>!
+            Questions?  Check out our <a href="/view_faq" target="_blank">FAQ</a>!
         </p>
         {% endif %}
         <p>
-            We are in the process of revising the site and
-            apologize for any inconvenience.
-            Please contact
+            Stuck?  Please contact
             <a href="mailto:microsetta@ucsd.edu">microsetta@ucsd.edu</a>
             for help.
+            <br/><br/>
+            <a href="https://microsetta.ucsd.edu" title="microsetta.ucsd.edu">Return to microsetta.ucsd.edu</a>
         </p>
     </div>
     {% endif %}

--- a/microsetta_interface/templates/sitebase.jinja2
+++ b/microsetta_interface/templates/sitebase.jinja2
@@ -54,9 +54,6 @@
     <div class="content">
 
     {% if show_breadcrumbs %}
-        <nav class="navbar navbar-expand-lg navbar-light" style="background-color:#e9ecef;">
-      <div class="collapse navbar-collapse" id="navbarText">
-    <ul class="navbar-nav mr-auto">
         <nav aria-label="breadcrumb">
           <ol class="breadcrumb">
             {% if is_home %}
@@ -67,19 +64,16 @@
             {%block breadcrumb%}
             {%endblock%}
           </ol>
-        </nav></ul>
+        </nav>
     {% endif %}
-
+        
+        <!-- Vue Form Generator references a container named "app" -->
+       <div class="container" id="app">
         {% if show_logout %}
             <div>
                 <a href="{{authrocket_url}}/logout?redirect_uri={{endpoint}}/logout">Log Out</a>
             </div>
         {% endif %}
-        
-        </div></nav>
-        
-        <!-- Vue Form Generator references a container named "app" -->
-        <div class="container" id="app">
 {%block content%}
 {%endblock%}
         </div>


### PR DESCRIPTION
### Master List of Changes ###

**sitebase.jinja2 edits**
- Softening language of notice that site is still changing (participants have reported confusion that they cannot do anything on the website because it is "undergoing revisions")
- Moved positions of text and clickable elements
- Creating a nav bar that nests the breadcrumbs elements and moves "Log Out" to the right side; this is in part to ensure users don't accidentally click on this link, as it's presented as the one of the first items in every page's main content

**signup_intermediate.jinja2 edits**
- Made changes to content, formatting, and moved positions of text, as per Kat's suggestions

**home.jinja2**
- Made changes to content, formatting, and moved positions of text
- Switched out "Refresh" button to be view AuthRocket profile.  I don't see any use case of a "Refresh" button as the pathway for participants would likely be: They see this page -> Check their email -> Find confirmation email -> Confirm email -> They go back to this page, which has already been refreshed for different content