### PR TITLE
Sample Notes Don't Say None

### DIFF
--- a/microsetta_interface/templates/sample.jinja2
+++ b/microsetta_interface/templates/sample.jinja2
@@ -134,7 +134,7 @@
           <div class="form-group">
             <label for="sample_notes" id="sample_notes_label">Notes</label>
             <div class="col-sm-10">
-                <textarea class="form-control" id="sample_notes" name="sample_notes" rows=3>{{ sample.sample_notes |e}}</textarea>
+                <textarea class="form-control" id="sample_notes" name="sample_notes" placeholder="Is there any additional information you think we should know about this sample?  Time of day, special diet, recent antibiotics, collection issues, etc." rows=3>{{ sample.sample_notes if sample.sample_notes is not none else '' |e}}</textarea>
             </div>
           </div>
          <button type="submit" class="btn btn-primary">Update</button>

--- a/microsetta_interface/templates/sample.jinja2
+++ b/microsetta_interface/templates/sample.jinja2
@@ -134,7 +134,7 @@
           <div class="form-group">
             <label for="sample_notes" id="sample_notes_label">Notes</label>
             <div class="col-sm-10">
-                <textarea class="form-control" id="sample_notes" name="sample_notes" placeholder="Is there any additional information you think we should know about this sample?  Time of day, special diet, recent antibiotics, collection issues, etc." rows=3>{{ sample.sample_notes if sample.sample_notes is not none else '' |e}}</textarea>
+                <textarea class="form-control" id="sample_notes" name="sample_notes" placeholder="(Optional) Is there else about this sample that you would like to add?" rows=3>{{ sample.sample_notes if sample.sample_notes is not none else '' |e}}</textarea>
             </div>
           </div>
          <button type="submit" class="btn btn-primary">Update</button>


### PR DESCRIPTION
Fixes sample_notes to not display None to the user when no notes are set.  Instead we show a placeholder asking for any additional information they wish to provide

Fix #8 