### PR TITLE
Question Triggers Weren't Hooked Up

### DIFF
--- a/microsetta_interface/templates/survey.jinja2
+++ b/microsetta_interface/templates/survey.jinja2
@@ -75,16 +75,16 @@
 
     <script type="text/javascript">
         var survey_model = {};
-        var survey_schema= {{survey_schema|tojson}} ;
+        var survey_schema= {{survey_schema|tojson}};
 
         if (survey_schema.fields !== null) {
             for (let field of survey_schema.fields) {
-                set_triggers(survey_model, field)
+                set_triggers(survey_model, field);
             }
         }
         for (let group of survey_schema.groups) {
             for (let field of group.fields) {
-                set_triggers(survey_model, field)
+                set_triggers(survey_model, field);
             }
         }
 

--- a/microsetta_interface/templates/survey.jinja2
+++ b/microsetta_interface/templates/survey.jinja2
@@ -81,10 +81,10 @@
             for (let field of survey_schema.fields) {
                 set_triggers(survey_model, field)
             }
-            for (let group of survey_schema.groups) {
-                for (let field of group.fields) {
-                    set_triggers(survey_model, field)
-                }
+        }
+        for (let group of survey_schema.groups) {
+            for (let field of group.fields) {
+                set_triggers(survey_model, field)
             }
         }
 


### PR DESCRIPTION
Fix #13 

Moved code out of surrounding if statement - this prevented question triggers from being linked up when a survey had no top level questions, only questions that were inside of grouped categories.  