### PR TITLE
Update account_details.jinja2 (only)

### DIFF
--- a/microsetta_interface/templates/account_details.jinja2
+++ b/microsetta_interface/templates/account_details.jinja2
@@ -80,11 +80,11 @@
                 <label for="state" name="state_label">State/Estado*</label>
 
                 {% set US_STATES = [
-                    ("CA", "California"),
                     ("AL", "Alabama"),
                     ("AK", "Alaska"),
                     ("AZ", "Arizona"),
                     ("AR", "Arkansas"),
+                    ("CA", "California"),
                     ("CO", "Colorado"),
                     ("CT", "Connecticut"),
                     ("DE", "Delaware"),

--- a/microsetta_interface/templates/account_details.jinja2
+++ b/microsetta_interface/templates/account_details.jinja2
@@ -42,42 +42,42 @@
 {% endblock %}
 {% block breadcrumb %}
     {% if not CREATE_ACCT %}
-    <li class="breadcrumb-item"><a href="/accounts/{{account.account_id}}">Account</a></li>
+    <li class="breadcrumb-item"><a href="/accounts/{{account.account_id}}">Profile</a></li>
     {% endif %}
-    <li class="breadcrumb-item active" aria-current="page">Account Details</li>
+    <li class="breadcrumb-item active" aria-current="page">Profile Details</li>
 {% endblock %}
 {% block content %}
 <div class="card">
-    <h5 class="card-header">Account Details</h5>
+    <h5 class="card-header">Profile Details</h5>
     <div class="card-body">
         <form id="acct_form" name="acct_form" method="post">
             <div class="form-group">
-                <label for="email" name="email_label">Email/Correo electrónico</label>
+                <label for="email" name="email_label">Email/Correo electrónico*</label>
                 <input id="email" name="email" class="form-control" type="hidden" value="{{account.email |e}}"/>
                 <input id="view_email" name="view_email" class="form-control" type="email" value="{{account.email |e}}" disabled="disabled" readonly/>
             </div>
             <div class="form-group">
-                <label for="first_name" name="first_name_label">First Name/Nombre</label>
+                <label for="first_name" name="first_name_label">First Name/Nombre*</label>
                 <input id="first_name" name="first_name" class="form-control" value="{{account.first_name |e}}" type="text" />
             </div>
             <div class="form-group">
-                <label for="last_name" name="last_name_label">Last Name/Nombre de Familia</label>
+                <label for="last_name" name="last_name_label">Last Name/Nombre de Familia*</label>
                 <input id="last_name" name="last_name" class="form-control" value="{{account.last_name |e}}" type="text" />
-            </div>
-            <div class="form-group">
-                <label for="street" name="street_label" >Street Address/Dirección</label>
-                <input id="street" name="street" class="form-control" value="{{account.address.street |e}}" type="text" />
-            </div>
-            <div class="form-group">
-                <label for="city" name="city_label">City/Ciudad</label>
-                <input id="city" name="city" class="form-control" value="{{account.address.city |e}}" type="text" />
             </div>
             <div class="form-group">
                 <p>
                 <strong>Note to non-US users:</strong> We are working on support for additional countries and
                 expect to have that available soon.
                 </p>
-                <label for="state" name="state_label">State/Estado</label>
+                <label for="street" name="street_label" >Street Address/Dirección*</label>
+                <input id="street" name="street" class="form-control" value="{{account.address.street |e}}" type="text" />
+            </div>
+            <div class="form-group">
+                <label for="city" name="city_label">City/Ciudad*</label>
+                <input id="city" name="city" class="form-control" value="{{account.address.city |e}}" type="text" />
+            </div>
+            <div class="form-group">
+                <label for="state" name="state_label">State/Estado*</label>
 
                 {% set US_STATES = [
                     ("CA", "California"),
@@ -140,7 +140,7 @@
                 </select>
             </div>
             <div class="form-group">
-                <label for="post_code" name="post_code_label">Zip Code/Código Postal</label>
+                <label for="post_code" name="post_code_label">Zip Code/Código Postal*</label>
                 <input id="post_code" name="post_code" class="form-control" value="{{account.address.post_code |e}}" type="text" />
             </div>
             {% if CREATE_ACCT %}
@@ -151,9 +151,9 @@
             {% endif %}
             <input id="country_code" name="country_code" type="hidden" value="{{account.address.country_code |e}}"/>
             {% if CREATE_ACCT %}
-            <button type="submit" class="btn btn-primary">Create Account</button>
+            <button type="submit" class="btn btn-primary">Save Profile</button>
             {% else %}
-            <button type="submit" class="btn btn-primary">Save</button>
+            <button type="submit" class="btn btn-primary">Save Profile</button>
             {% endif %}
         </form>
     </div>


### PR DESCRIPTION
New PR that targets only the account_details page.

* Changed name of page to "profile" to reflect purpose of page
* Added asterisks to clarify that each input field is required
* Changed button text to reflect its action
* Moved note about non-U.S. participants to be higher
* Moved CA option to be in alphabetical order (although if possible--could the default option be set to blank, as I believe now the default option would be Alabama?)