### PR TITLE
Issue 38

### DIFF
--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -516,11 +516,6 @@ def get_authrocket_callback(token, redirect_uri=None):
     return redirect(HOME_URL)
 
 
-def get_signup_intermediate():
-    output = _render_with_defaults('signup_intermediate.jinja2')
-    return output
-
-
 def get_logout():
     session.clear()
     return redirect(HOME_URL)

--- a/microsetta_interface/routes.yaml
+++ b/microsetta_interface/routes.yaml
@@ -85,19 +85,6 @@ paths:
         '302':
           description: Returning home
 
-  '/signup_intermediate':
-    get:
-      operationId: microsetta_interface.implementation.get_signup_intermediate
-      tags:
-        - Authentication
-      responses:
-        '200':
-          description: Page with additional information prior to pass off to AuthRocket
-          content:
-            text/html:
-              schema:
-                type: string
-
   '/logout':
     get:
       operationId: microsetta_interface.implementation.get_logout

--- a/microsetta_interface/templates/sitebase.jinja2
+++ b/microsetta_interface/templates/sitebase.jinja2
@@ -74,7 +74,7 @@
             <a class="dropdown-item" href="{{authrocket_url}}/logout?redirect_uri={{endpoint}}/logout">Log Out</a>
           {% else %}
               <a class="dropdown-item" href="{{authrocket_url}}/login?redirect_uri={{endpoint}}/authrocket_callback">Log In</a>
-              <a class="dropdown-item" href="/signup_intermediate">Sign Up</a>
+              <a class="dropdown-item" href="{{authrocket_url}}/signup?redirect_uri={{endpoint}}/authrocket_callback">Sign Up</a>
           {% endif %}
           </div>
         </div>


### PR DESCRIPTION
Fixes #38 : changes "sign up" drop-down link to go same place as "sign up" body link (i.e., authrocket sign-up page).  Removes now-defunct signup_intermediate api endpoint.