### PR TITLE
Enforce MM/DD/YYYY for Sample Date

### DIFF
--- a/microsetta_interface/templates/sample.jinja2
+++ b/microsetta_interface/templates/sample.jinja2
@@ -10,6 +10,37 @@
     <script type="text/javascript" src="/static/vendor/js/jquery.timepicker.min.js"></script>
 
     <script>
+        //  Let jquery validate check mm/dd/yyyy
+        $.validator.addMethod("monthDayYear", function(value, element)
+        {
+        //  Derived from the dateITA (dd/mm/yyyy) jquery validate additional method
+        //  by swapping day and month in the parseInt calls.
+        //  See the additional-methods.js file in the jquery-validate distribution
+        //  Note: the additional-methods.js file is
+        //      Copyright (c) 2020 Jörn Zaefferer
+        //      Released under the MIT license
+	        var check = false;
+	        var regex = /^\d{1,2}\/\d{1,2}\/\d{4}$/;
+	        if (regex.test(value))
+	        {
+		        var data = value.split("/");
+		        var mm = parseInt(data[0], 10);
+		        var dd = parseInt(data[1], 10);
+		        var yyyy = parseInt(data[2], 10);
+                var parsedDate = new Date(Date.UTC(yyyy, mm - 1, dd, 12, 0, 0, 0));
+                if ((parsedDate.getUTCFullYear() === yyyy) &&
+                    (parsedDate.getUTCMonth() === mm - 1) &&
+                    (parsedDate.getUTCDate() === dd)) {
+                    check = true;
+                } else {
+                    check = false;
+                }
+            } else {
+                check = false;
+            }
+            return this.optional(element) || check;
+        }, "Required Format: MM/DD/YYYY");
+
         $(document).ready(function(){
             let form_name = 'sample_form';
             preventImplicitSubmission(form_name);
@@ -46,7 +77,10 @@
                     // The key name on the left side is the name attribute
                     // of an input field. Validation rules are defined
                     // on the right side
-                    sample_date: "required",
+                    sample_date: {
+                        required: true,
+                        monthDayYear: true
+                    },
                     sample_time: "required",
                     {% if not is_environmental %}
                     sample_site: "required",


### PR DESCRIPTION
Fix #2 

Used jquery validate to validate date on the sample page.  Required a custom validator function which was cobbled together from the jquery-validate additional-methods plugins/examples file

<img width="739" alt="Screen Shot 2020-09-23 at 4 42 11 PM" src="https://user-images.githubusercontent.com/26189444/94085742-c42ab180-fdbd-11ea-8225-0d7caf6c19ae.png">
<img width="753" alt="Screen Shot 2020-09-23 at 4 42 05 PM" src="https://user-images.githubusercontent.com/26189444/94085747-c55bde80-fdbd-11ea-93d9-a73cec6b591d.png">
<img width="737" alt="Screen Shot 2020-09-23 at 4 41 54 PM" src="https://user-images.githubusercontent.com/26189444/94085750-c5f47500-fdbd-11ea-91cd-233784c5ec64.png">
<img width="692" alt="Screen Shot 2020-09-23 at 4 41 42 PM" src="https://user-images.githubusercontent.com/26189444/94085751-c5f47500-fdbd-11ea-9378-0759a939ff61.png">
<img width="638" alt="Screen Shot 2020-09-23 at 4 41 31 PM" src="https://user-images.githubusercontent.com/26189444/94085752-c68d0b80-fdbd-11ea-9647-66688db09bf0.png">
