### PR TITLE
fixes #39 (inconsistent fonts on page)

### DIFF
--- a/microsetta_interface/templates/account_overview.jinja2
+++ b/microsetta_interface/templates/account_overview.jinja2
@@ -25,8 +25,8 @@
   min-width: 277.5px;
 }
 .info-card {
-  border: solid 1px var(--forms_cards_outsideborder);
-  background-color: var(--pi-jumbotron-bg);
+  border: solid 1px #e5e5e5;
+  background-color: #eceeef;
   min-width: 200px;
 }
 
@@ -34,34 +34,10 @@
   min-width: 200px;
 }
 
-.info-text {
-  font-family: Muli;
-  font-size: 16px;
-  font-weight: normal;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: 1.75;
-  letter-spacing: normal;
-  color: var(--Body);
-}
-
 #new-source-title {
-  font-family: Muli;
-  font-size: 24px;
-  font-weight: 600;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: 1.67;
-  letter-spacing: normal;
-  color: var(--Body);
   text-align: center;
 }
 
-#source {
-  padding-left: 1.5625rem;
-  padding-right: 1.5625rem;
-  padding-top: 1.875rem;
-}
 </style>
 {% endblock %}
 {% block breadcrumb %}
@@ -118,18 +94,18 @@
 <br>
 <h2 id="new-source-title">What is the Source of Your Sample?</h2>
 <br>
-<div class="source selection container">
+<div class="container">
     <div class="row">
         <div class="card-deck h-100">
             <div class="card info-col border-0 mb-3">
                 <div class="card bg-light mb-3 info-card">
                     <div class="card-body">
-                        <p class="info-text">Our lab needs to know what type of sample(s) you are submitting (a.k.a. the “source”). Add a new source and assign samples to it so we can perform the correct analysis in our laboratory </p>
+                        <p>Our lab needs to know what type of sample(s) you are submitting (a.k.a. the “source”). Add a new source and assign samples to it so we can perform the correct analysis in our laboratory. </p>
                     </div>
                 </div>
                 <div class="card bg-light info-card">
                     <div class="card-body">
-                        <p class="info-text">If you have multiple sources, you may add one source at a time. You can return to this page after you finish registering the first one.</p>
+                        <p>If you have multiple sources, you may add one source at a time. You can return to this page after you finish registering the first one.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Turns out the issue is a result of taking zeplin at its word, css-wise.  Unfortunately, its auto-generated, overly-specified boilerplate css doesn't include backup fonts, thus defaulting to Times New Roman if one doesn't have Muli ... it also references css variables that we don't have defined :(. I've tried to excise the bits that are either breaking things or unused in the page.  Now looks like this:
<img width="972" alt="Screen Shot 2020-09-24 at 3 56 21 PM" src="https://user-images.githubusercontent.com/10677935/94208618-1b448b00-fe7f-11ea-8012-3605f9e6ff51.png">
