### PR TITLE
Disables interface controls for disassociating samples and editing samples

### DIFF
--- a/microsetta_interface/templates/sample.jinja2
+++ b/microsetta_interface/templates/sample.jinja2
@@ -68,6 +68,11 @@
                 }
             });
 
+            {% if sample.sample_edit_locked and not admin_mode %}
+            $("#sample_date").datepicker('disable');
+            $("#sample_time").prop('disabled', true);
+            {% endif %}
+
             $("form[name='" + form_name + "']").validate({
                 // don't automatically move into the Date field
                 // as that triggers the pop up and it's annoying
@@ -112,6 +117,11 @@
 {% block content %}
     <div class="container">
       <form method="post" id="sample_form" name="sample_form">
+          {% if sample.sample_edit_locked %}
+          <div class="alert alert-success" role="alert">
+              Sample Recorded, Editing is Locked
+          </div>
+          {% endif %}
           <div class="form-group row">
             <label for="sample" name="sample_label" class="col-sm-2 col-form-label">Barcode</label>
             <div class="col-sm-4">
@@ -138,6 +148,7 @@
           {% if not is_environmental %}
           <div class="form-group row">
               <div class="col-sm-12">
+                {% if not sample.sample_edit_locked or admin_mode %}
                 <div class="row">
                     <div class="col-sm-6">
                     <ul>
@@ -147,10 +158,11 @@
                     </ul>
                     </div>
                 </div>
+                {% endif %}
                 <div class="row">
                     <label for="sample_site" name="sample_site_label" class="col-sm-2 col-form-label">Site sampled</label>
                     <div class="col-sm-4">
-                      <select id="sample_site" name="sample_site" class="form-control" required>
+                      <select id="sample_site" name="sample_site" class="form-control" required {% if sample.sample_edit_locked and not admin_mode %}disabled{% endif %}>
                         {% if not sample.sample_site %}
                         <option disabled selected value> -- Select a sample type -- </option>
                         {% endif %}
@@ -168,10 +180,10 @@
           <div class="form-group">
             <label for="sample_notes" id="sample_notes_label">Notes</label>
             <div class="col-sm-10">
-                <textarea class="form-control" id="sample_notes" name="sample_notes" placeholder="(Optional) Is there else about this sample that you would like to add?" rows=3>{{ sample.sample_notes if sample.sample_notes is not none else '' |e}}</textarea>
+                <textarea class="form-control" id="sample_notes" name="sample_notes" placeholder="(Optional) Is there else about this sample that you would like to add?" rows=3 {% if sample.sample_edit_locked and not admin_mode %}disabled{% endif %}>{{ sample.sample_notes if sample.sample_notes is not none else '' |e}}</textarea>
             </div>
           </div>
-         <button type="submit" class="btn btn-primary">Update</button>
+         <button type="submit" class="btn btn-primary" {% if sample.sample_edit_locked and not admin_mode %}disabled{% endif %}>Update</button>
       </form>
     </div>
 {% endblock %}

--- a/microsetta_interface/templates/source.jinja2
+++ b/microsetta_interface/templates/source.jinja2
@@ -188,7 +188,9 @@
                 </div>
                 {% endif %}  <!-- end of if is_human -->
                 <div class="col-sm">
-                    <form name="remove_{{ sample.sample_id }}_form" method="post" action="/accounts/{{ account_id }}/sources/{{ source_id }}/samples/{{ sample.sample_id }}/remove" onsubmit="return verifyDissociateSample('{{sample.sample_id}}');"><button type="submit" class="btn btn-danger">Remove</button></form>
+                    <form name="remove_{{ sample.sample_id }}_form" method="post" action="/accounts/{{ account_id }}/sources/{{ source_id }}/samples/{{ sample.sample_id }}/remove" onsubmit="return verifyDissociateSample('{{sample.sample_id}}');">
+                        <button type="submit" class="btn btn-danger" {% if sample.sample_remove_locked and not admin_mode %}disabled{% endif %}>Remove</button>
+                    </form>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Interface didn't have support for using sample_locked flag in the past.  With split from sample_locked to sample_edit_locked and sample_remove_locked, this updates interface to disable editing controls or removal from sources as appropriate.  

May want to wait for popper.js to come in so we can add a tooltip to the remove button before merging.  