### PR TITLE
Fix broken vioscreen pdf links

### DIFF
--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -906,6 +906,7 @@ def get_source(*, account_id=None, source_id=None):
     # Identify answered surveys for the samples
     for sample in samples_output:
         sample['ffq'] = None
+        sample['ffq_status'] = None
         sample_id = sample['sample_id']
         # TODO:  This is a really awkward and slow way to get this information
         has_error, per_sample_answers, _ = ApiRequest.get(
@@ -917,6 +918,7 @@ def get_source(*, account_id=None, source_id=None):
         for answer in per_sample_answers:
             if answer['survey_template_id'] == VIOSCREEN_ID:
                 sample['ffq'] = answer['survey_id']
+                sample['ffq_status'] = answer['survey_status']
 
     # prettify datetime
     needs_assignment = False

--- a/microsetta_interface/templates/source.jinja2
+++ b/microsetta_interface/templates/source.jinja2
@@ -198,7 +198,7 @@
                       <div id="btn-view-{{ sample.sample_id }}" ></div>
                 </div>
                 <div class="col-sm">
-                {% if sample.ffq %}
+                {% if sample.ffq and sample.ffq_status == 3 %}
                     <a class="btn btn-outline-success" href="/accounts/{{account_id}}/sources/{{source_id}}/surveys/{{sample.ffq}}/reports/topfoodreport">View Top Food Report</a>
                 {% else %}
                     <a class="btn btn-outline-primary" href="/accounts/{{account_id}}/sources/{{source_id}}/samples/{{sample.sample_id}}/survey_templates/{{vioscreen_id}}">Food Frequency Questionnaire</a><span class="fa fa-unchecked"/>


### PR DESCRIPTION
One case where we had users getting broken pdf links was from them having a status of 0, 1, or 2 in the database and having a -DISTINCT- vioscreen survey ID from their primary ID (matching these two still forces them to take a new survey as of now)

Uses vioscreen status to decide whether to show report pdf or questionnaire

Relies on matching PR in microsetta-private-api.  