### PR TITLE
Template for fixing button mashing

### DIFF
--- a/microsetta_interface/static/input_util.js
+++ b/microsetta_interface/static/input_util.js
@@ -34,6 +34,13 @@ function preventImplicitSubmission(form_name){
     });
 }
 
+function disableInputOnSubmit(form_selector, input_selector, disabled_text)
+{
+    $(form_selector).submit(function() {
+        $(input_selector).prop("disabled", true).val(disabled_text);
+    });
+}
+
 function replicate_text(input_selector, destination_selector) {
     $(input_selector).bind('input', function(){
         $(this).val(function(_, v){

--- a/microsetta_interface/templates/create_nonhuman_source.jinja2
+++ b/microsetta_interface/templates/create_nonhuman_source.jinja2
@@ -5,12 +5,13 @@
     <script>
         $(document).ready(function(){
             preventImplicitSubmission("new_source_form");
+            disableInputOnSubmit("#new_source_form", "#submit_button", "Creating Source...")
         });
     </script>
 {% endblock %}
 {% block content %}
     <div class="container">
-        <form method="post" name="new_source_form" action="/accounts/{{account_id}}/create_nonhuman_source/">
+        <form method="post" id="new_source_form" name="new_source_form" action="/accounts/{{account_id}}/create_nonhuman_source/">
             <div class="form-group">
                 <label for="source_name" name="source_name_label">Environment name (e.g., microwave):</label>
                 <input id="source_name" name="source_name" class="form-control" type="text" required/>
@@ -19,7 +20,7 @@
                 <label for="source_description" name="source_description_label">Environment description (optional):</label>
                 <input id="source_description" name="source_description" class="form-control" type="text"/>
              </div>
-            <input type="submit" class="btn btn-primary" value="Create Source"/>
+            <input id="submit_button" type="submit" class="btn btn-primary" value="Create Source"/>
         </form>
     </div>
 {% endblock %}


### PR DESCRIPTION
Added utility method to disable form inputs and change their text on form submit, used in create_nonhuman_source

We'll have to do something like this on all the forms we don't want users button mashing on.  Also, firefox prevents form submit button mashing by default, so rather difficult to reproduce on there.  

Fix #103 