### PR TITLE
Account Creation by Activation Code

### DIFF
--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -1266,6 +1266,49 @@ def get_interactive_account_search(email_query):
                                  accounts=accounts)
 
 
+def get_interactive_activation(email_query=None, code_query=None):
+    if not session.get(ADMIN_MODE_KEY, False):
+        raise Unauthorized()
+
+    do_return = False
+    diagnostics = None
+    if email_query is not None:
+        do_return, diagnostics, _ = ApiRequest.get(
+            "/admin/search/activation",
+            params={"email_query": email_query}
+        )
+    elif code_query is not None:
+        do_return, diagnostics, _ = ApiRequest.get(
+            "/admin/search/activation",
+            params={"code_query": code_query}
+        )
+    if do_return:
+        return diagnostics
+
+    return _render_with_defaults(
+        'admin_activation_codes.jinja2',
+        email_query=email_query,
+        code_query=code_query,
+        diagnostics=diagnostics
+    )
+
+
+def post_generate_activation(body):
+    if not session.get(ADMIN_MODE_KEY, False):
+        raise Unauthorized()
+
+    email = body["email"]
+    do_return, diagnostics, _ = ApiRequest.post(
+        "/admin/activation",
+        json={"emails": [email]}
+    )
+
+    if do_return:
+        return diagnostics
+
+    return get_interactive_activation(email, None)
+
+
 def get_system_message():
     if not session.get(ADMIN_MODE_KEY, False):
         raise Unauthorized()

--- a/microsetta_interface/routes.yaml
+++ b/microsetta_interface/routes.yaml
@@ -660,6 +660,47 @@ paths:
               schema:
                 type: string
 
+  '/admin/activation':
+    get:
+      operationId: microsetta_interface.implementation.get_interactive_activation
+      tags:
+        - Admin
+      parameters:
+        - in: query
+          name: email_query
+          description: Email to search for
+          schema:
+            type: string
+        - in: query
+          name: code_query
+          description: Activation code to search for
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activation code info for query
+          content:
+            text/html:
+              schema:
+                type: string
+    post:
+      operationId: microsetta_interface.implementation.post_generate_activation
+      tags:
+        - Admin
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Search results showing new email
+          content:
+            text/html:
+              schema:
+                type: string
+
   '/admin/system_message':
     get:
       operationId: microsetta_interface.implementation.get_system_message

--- a/microsetta_interface/routes.yaml
+++ b/microsetta_interface/routes.yaml
@@ -641,6 +641,22 @@ paths:
               schema:
                 type: array
 
+  '/check_activation_code':
+    get:
+      operationId: microsetta_interface.implementation.get_ajax_check_activation_code
+      tags:
+        - Activation
+      parameters:
+        - $ref: '#/components/parameters/activation_code'
+        - $ref: '#/components/parameters/email'
+      responses:
+        '200':
+          description: Result of check
+          content:
+            text/html:
+              schema:
+                type: string
+
   '/admin/account_search':
     get:
       operationId: microsetta_interface.implementation.get_interactive_account_search
@@ -759,6 +775,20 @@ components:
       schema:
         $ref: '#/components/schemas/account_id'
       required: true
+    activation_code:
+      name: code
+      in: query
+      description: Activation code
+      schema:
+        $ref: '#/components/schemas/activation_code'
+      required: true
+    email:
+      name: email
+      in: query
+      description: User's email
+      schema:
+        $ref: '#/components/schemas/email'
+      required: true
     kit_id:
       name: kit_id
       in: path
@@ -822,6 +852,10 @@ components:
       type: string
       readOnly: true
       example: "aaaaaaaa-bbbb-cccc-dddd-eeeeffffffff"
+    email:
+      type: string
+      format: email
+      example: "janedoe@example.com"
     source_id:
       type: string
       readOnly: true # sent in GET, not in POST/PUT/PATCH
@@ -843,4 +877,7 @@ components:
     kit_name:
       type: string
       example: "aaaaa"
+    activation_code:
+      type: string
+      example: TMI-XXXXX-XXXXX-XXXXX
 

--- a/microsetta_interface/templates/account_details.jinja2
+++ b/microsetta_interface/templates/account_details.jinja2
@@ -29,9 +29,20 @@
                     post_code: "required",
                     {% if CREATE_ACCT %}
                     kit_name: {
-                        required: true,
+                        required: "#code:blank",
                         remote: {
                             url: "/check_kit_valid"
+                        }
+                    },
+                    code: {
+                        required: "#kit_name:blank",
+                        remote: {
+                            url: "/check_activation_code",
+                            data: {
+                                email: function() {
+                                    return $("#email").val();
+                                }
+                            }
                         }
                     },
                     {% endif %}
@@ -153,9 +164,21 @@
                 <input id="post_code" name="post_code" class="form-control" value="{{account.address.post_code |e}}" type="text" />
             </div>
             {% if CREATE_ACCT %}
-            <div class="form-group">
-                <label for="kit_name" name="kit_name_label">Kit ID/ID del kit</label>
-                <input id="kit_name" name="kit_name" class="form-control" type="text"/>
+            <div class="card mb-3">
+                <div class="card-header">
+                    Activation Info
+                </div>
+                <div class="card-body">
+                    <div class="form-group">
+                        <label for="kit_name" name="kit_name_label">Kit ID/ID del kit</label>
+                        <input id="kit_name" name="kit_name" class="form-control" type="text"/>
+                    </div>
+                    <div class="text-center">-OR-</div>
+                    <div class="form-group">
+                        <label for="code" name="code_label">Activation Code</label>
+                        <input id="code" name="code" class="form-control" type="text" placeholder="TMI-XXXXX-XXXXX-XXXXX"/>
+                    </div>
+                </div>
             </div>
             {% endif %}
             {% if CREATE_ACCT %}

--- a/microsetta_interface/templates/admin_activation_codes.jinja2
+++ b/microsetta_interface/templates/admin_activation_codes.jinja2
@@ -14,8 +14,9 @@
     </form>
     <form method="post">
         <label for="email">Email:</label>
-        <input type="text" name="email">
-        <input type="submit" value="Generate">
+        <input type="text" name="email" value="{{ email_query |e if email_query is not none}}">
+        <input type="submit" name="generate" value="Generate">
+        <input type="submit" name="generate_send" value="Generate + Send Email">
     </form>
 <h4>Search Results</h4>
 <div class="container">

--- a/microsetta_interface/templates/admin_activation_codes.jinja2
+++ b/microsetta_interface/templates/admin_activation_codes.jinja2
@@ -1,0 +1,56 @@
+{% extends "sitebase.jinja2" %}
+{% set page_title = "Admin Activation Codes" %}
+{% set show_breadcrumbs = False %}
+{% block content %}
+    <form method="get">
+        <label for="email_query">Email:</label>
+        <input type="text" name="email_query" value="{{ email_query |e if email_query is not none}}">
+        <input type="submit" value="Search">
+    </form>
+    <form method="get">
+        <label for="code_query">Activation Code:</label>
+        <input type="text" name="code_query" value="{{ code_query |e if code_query is not none}}">
+        <input type="submit" value="Search">
+    </form>
+    <form method="post">
+        <label for="email">Email:</label>
+        <input type="text" name="email">
+        <input type="submit" value="Generate">
+    </form>
+<h4>Search Results</h4>
+<div class="container">
+    {% if diagnostics is not none and diagnostics|length > 0 %}
+    <div class="list-group">
+        <div class="row">
+            <div class="col-sm">
+                <i>Email</i>
+            </div>
+            <div class="col-sm">
+                <i>Code</i>
+            </div>
+            <div class="col-sm">
+                <i>Activated</i>
+            </div>
+        </div>
+        {% for row in diagnostics %}
+        <div class="container list-group-item {{loop.cycle('odd', 'even') }}">
+          <div class="row">
+            <div class="col-sm">
+              {{ row.email |e}}
+            </div>
+            <div class="col-sm">
+              {{ row.code|e }}
+            </div>
+            <div class="col-sm">
+                {{ row.activated|e }}
+            </div>
+          </div>
+        </div>
+        {% endfor %}
+    </div>
+    <br/><br/>
+    {% else %}
+    No accounts found
+    {% endif %}
+</div>
+{% endblock %}

--- a/microsetta_interface/templates/sitebase.jinja2
+++ b/microsetta_interface/templates/sitebase.jinja2
@@ -43,6 +43,7 @@
       <a class="btn btn-outline-success" href="/admin/system_message">System Panel</a>
       <a class="btn btn-outline-success" href="/admin/emperor_playground">Emperor Playground</a>
       <a class="btn btn-outline-success" href="{{authrocket_url}}/logout?redirect_uri={{endpoint}}/logout">Log Out</a>
+      <a class="btn btn-outline-success" href="/admin/activation">Activation Codes</a>
       <form class="form-inline" action="/admin/account_search" method="get">
         <input id="email_query" name="email_query" class="form-control mr-sm-2" type="search" placeholder="User Email" aria-label="Search"/>
         <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Find Account</button>


### PR DESCRIPTION
Lets user enter an Activation Code instead of a Kit ID to login.  

Probably shouldn't merge this until there is actually a way to distribute activation codes to users??