### PR TITLE
Survey Aesthetics

### DIFF
--- a/microsetta_interface/templates/new_participant.jinja2
+++ b/microsetta_interface/templates/new_participant.jinja2
@@ -156,10 +156,10 @@
            <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}} <span class="required-field">*</span></p>
     </div>
     <table>
-        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <div class="red right required-field" required data-rule-required="true">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}</td><td><input tabindex="7" type="text" name="parent_1_name" id="0-6-form_parent_1_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}</td><td><input tabindex="8" type="text" name="parent_2_name" id="0-6-form_parent_2_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}</td><td><input tabindex="7" type="text" name="parent_1_name" id="0-6-form_parent_1_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}</td><td><input tabindex="8" type="text" name="parent_2_name" id="0-6-form_parent_2_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
         <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}</td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
         <tr><td><input type="submit" id="0-6-submit_button" value="I Accept"></td><td></td></tr>
     </table>
@@ -176,15 +176,15 @@
            <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_SIMPLIFIED'] |e}} <span class="required-field">*</span></p>
     </div>
     <p><table>
-        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
     </table></p>
     <div>
     <h4>{{ tl['PERSON_ATTAINING_ASSENT'] |e}}</h4>
     <p><input value="Yes" type="checkbox" name="consent_witness" id="consent_witness" required data-rule-required="true"> {{ tl['TEXT_ASSENT_WITNESS'] |e}} <span class="required-field">*</span></p>
     </div>
     <p><table>
-        <tr><td><label for='obtainer_name'>{{ tl['OBTAINER_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="obtainer_name" id="obtainer_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td><label for='obtainer_name'>{{ tl['OBTAINER_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="obtainer_name" id="obtainer_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
     </table></p>
     <hr>
 <div class='scrolltext'>
@@ -198,8 +198,8 @@
            <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}} <span class="required-field">*</span></p>
     </div>
     <table>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}: </td><td><input tabindex="7" type="text" name="parent_1_name" id="7-12-form_parent_1_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}: </td><td><input tabindex="8" type="text" name="parent_2_name" id="7-12-form_parent_2_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}: </td><td><input tabindex="7" type="text" name="parent_1_name" id="7-12-form_parent_1_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}: </td><td><input tabindex="8" type="text" name="parent_2_name" id="7-12-form_parent_2_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
         <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}: </td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
         <tr><td><input type="submit" id="7-12-submit_button" value="I Accept"></td><td></td></tr>
     </table>
@@ -217,8 +217,8 @@
            <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_1'] |e}} <span class="required-field">*</span></p>
     </div>
     <p><table>
-        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}: </label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}: </td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}: </label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}: </td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
     </table></p>
     <hr>
     <div class='scrolltext'>
@@ -232,8 +232,8 @@
            <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}} <span class="required-field">*</span></p>
     </div>
     <table>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}: </td><td><input tabindex="7" type="text" name="parent_1_name" id="13-17-form_parent_1_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}: </td><td><input tabindex="7" type="text" name="parent_2_name" id="13-17-form_parent_2_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}: </td><td><input tabindex="7" type="text" name="parent_1_name" id="13-17-form_parent_1_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}: </td><td><input tabindex="7" type="text" name="parent_2_name" id="13-17-form_parent_2_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
         <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}: </td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
         <tr><td><input type="submit" id="13-17-submit_button" value="I Accept"></td><td></td></tr>
     </table>
@@ -254,8 +254,8 @@
            <p><input value="Yes" type="checkbox" name="consent" id="consent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_1'] |e}} <span class="required-field">*</span></p>
     </div>
     <p><table>
-        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}: </label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}: </td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}: </label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}: </td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <span class="required-field">*</span></td></tr>
         <tr><td><input type="submit" id="18-submit_button" value="I Accept"></td><td></td></tr>
     </table></p>
     </form>

--- a/microsetta_interface/templates/new_participant.jinja2
+++ b/microsetta_interface/templates/new_participant.jinja2
@@ -118,6 +118,11 @@
   width: 80%;
   margin: 0 auto;
 }
+
+.required-field {
+    color: red;
+    display: inline-block;
+}
 </style>
 {% endblock %}
 {% block breadcrumb %}
@@ -148,13 +153,13 @@
         <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{{ tl['BILL_OF_RIGHTS']|e}}</a><br/>
         <form id="0-6-form" name="consent_info" onsubmit="return validate06();" action="{{ post_url }}" method="post">
            <input type="hidden" name="age_range" value="0-6">
-           <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}}</p>
+           <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}} <span class="required-field">*</span></p>
     </div>
     <table>
-        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"><div class="red right">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"><div class="red right" required data-rule-required="true">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}</td><td><input tabindex="7" type="text" name="parent_1_name" id="0-6-form_parent_1_name" required data-rule-required="true"></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}</td><td><input tabindex="8" type="text" name="parent_2_name" id="0-6-form_parent_2_name" required data-rule-required="true"></td></tr>
+        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <div class="red right required-field" required data-rule-required="true">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}</td><td><input tabindex="7" type="text" name="parent_1_name" id="0-6-form_parent_1_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}</td><td><input tabindex="8" type="text" name="parent_2_name" id="0-6-form_parent_2_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
         <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}</td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
         <tr><td><input type="submit" id="0-6-submit_button" value="I Accept"></td><td></td></tr>
     </table>
@@ -168,18 +173,18 @@
         <hr>
         <form id="7-12-form" name="consent_info" onsubmit="return validate712();" action="{{ post_url }}" method="post">
         <input type="hidden" name="age_range" value="7-12">
-           <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_SIMPLIFIED'] |e}}</p>
+           <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_SIMPLIFIED'] |e}} <span class="required-field">*</span></p>
     </div>
     <p><table>
-        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"><div class="red right">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"><div class="red right">*</div></td></tr>
+        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
     </table></p>
     <div>
     <h4>{{ tl['PERSON_ATTAINING_ASSENT'] |e}}</h4>
-    <p><input value="Yes" type="checkbox" name="consent_witness" id="consent_witness" required data-rule-required="true"> {{ tl['TEXT_ASSENT_WITNESS'] |e}}</p>
+    <p><input value="Yes" type="checkbox" name="consent_witness" id="consent_witness" required data-rule-required="true"> {{ tl['TEXT_ASSENT_WITNESS'] |e}} <span class="required-field">*</span></p>
     </div>
     <p><table>
-        <tr><td><label for='obtainer_name'>{{ tl['OBTAINER_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="obtainer_name" id="obtainer_name" required data-rule-required="true"><div class="red right">*</div></td></tr>
+        <tr><td><label for='obtainer_name'>{{ tl['OBTAINER_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="obtainer_name" id="obtainer_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
     </table></p>
     <hr>
 <div class='scrolltext'>
@@ -190,12 +195,12 @@
 <div class="" id="consent">
         <hr>
             <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{{ tl['BILL_OF_RIGHTS']|e}}</a><br/>
-           <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}}</p>
+           <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}} <span class="required-field">*</span></p>
     </div>
     <table>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}</td><td><input tabindex="7" type="text" name="parent_1_name" id="7-12-form_parent_1_name" required data-rule-required="true"></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}</td><td><input tabindex="8" type="text" name="parent_2_name" id="7-12-form_parent_2_name" required data-rule-required="true"></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}</td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}: </td><td><input tabindex="7" type="text" name="parent_1_name" id="7-12-form_parent_1_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}: </td><td><input tabindex="8" type="text" name="parent_2_name" id="7-12-form_parent_2_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}: </td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
         <tr><td><input type="submit" id="7-12-submit_button" value="I Accept"></td><td></td></tr>
     </table>
     </form>
@@ -209,11 +214,11 @@
         <hr>
         <form id="13-17-form" name="consent_info" onsubmit="return validate1317();" action="{{ post_url }}" method="post">
            <input type="hidden" name="age_range" value="13-17">
-           <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_1'] |e}}</p>
+           <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_1'] |e}} <span class="required-field">*</span></p>
     </div>
     <p><table>
-        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"><div class="red right">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"><div class="red right">*</div></td></tr>
+        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}: </label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}: </td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
     </table></p>
     <hr>
     <div class='scrolltext'>
@@ -224,12 +229,12 @@
     <div class="" id="consent">
         <hr>
         <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{{ tl['BILL_OF_RIGHTS']|e}}</a><br/>
-           <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}}</p>
+           <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}} <span class="required-field">*</span></p>
     </div>
     <table>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}</td><td><input tabindex="7" type="text" name="parent_1_name" id="13-17-form_parent_1_name" required data-rule-required="true"></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}</td><td><input tabindex="7" type="text" name="parent_2_name" id="13-17-form_parent_2_name" required data-rule-required="true"></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}</td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}: </td><td><input tabindex="7" type="text" name="parent_1_name" id="13-17-form_parent_1_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}: </td><td><input tabindex="7" type="text" name="parent_2_name" id="13-17-form_parent_2_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}: </td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
         <tr><td><input type="submit" id="13-17-submit_button" value="I Accept"></td><td></td></tr>
     </table>
     </form>
@@ -246,11 +251,11 @@
         <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{{ tl['BILL_OF_RIGHTS']|e}}</a><br/>
         <form id="18-form" name="consent_info" onsubmit="return min_validation('18-form');" action="{{ post_url }}" method="post">
         <input type="hidden" name="age_range" value="18-plus">
-           <p><input value="Yes" type="checkbox" name="consent" id="consent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_1'] |e}}</p>
+           <p><input value="Yes" type="checkbox" name="consent" id="consent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_1'] |e}} <span class="required-field">*</span></p>
     </div>
     <p><table>
-        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}</label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"><div class="red right">*</div></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"><div class="red right">*</div></td></tr>
+        <tr><td><label for='participant_name'>{{ tl['PARTICIPANT_NAME'] |e}}: </label></td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}: </td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"> <div class="red right required-field">*</div></td></tr>
         <tr><td><input type="submit" id="18-submit_button" value="I Accept"></td><td></td></tr>
     </table></p>
     </form>

--- a/microsetta_interface/templates/survey.jinja2
+++ b/microsetta_interface/templates/survey.jinja2
@@ -5,11 +5,60 @@
     <script type="text/javascript" src="/static/vendor/js/vue-2.5.17.min.js"></script>
     <script type="text/javascript" src="/static/vendor/vue-form-generator-2.3.4/vfg.js"></script>
     <link rel="stylesheet" type="text/css" href="/static/vendor/vue-form-generator-2.3.4/vfg.css">
+    <style type="text/css">
+        .vue-form-generator .field-radios .radio-list label {
+            padding-right: 25px;
+            display: inline-block;
+        }
+
+        .survey-nav-button {
+            padding: 6px 12px;
+            color: #ffffff!important;
+            background-color: #337ab7!important;
+            border: 1px solid #cccccc;
+            border-radius: 4px;
+            font-size: 14px;
+            font-weight: 400;
+            line-height: 1.42857143;
+            text-align: center;
+            display: none;
+        }
+
+        .form-group label span{
+            font-weight: 700;
+        }
+
+        .form-group {
+            padding-bottom: 5px;
+        }
+
+        .field-wrap {
+            font-size: 90%;
+        }
+
+        #form-progress {
+            width: 100%;
+            text-align: center;
+            display: none;
+            font-weight: bold;
+        }
+    </style>
     <script>
         var result_txt = "";
         var error_txt = "";
+        var form_submitted = 0;
 
         function postSurvey() {
+            fieldsetObject = document.getElementsByTagName("fieldset");
+
+            // workaround to make the first six sections of the survey visible to the DOM so they submit, but hidden to the user
+            for(i=1; i<(fieldsetObject.length-1); i++) {
+                fieldsetObject[i].style.position = "absolute";
+                fieldsetObject[i].style.top = "-9999px";
+                fieldsetObject[i].style.left = "-9999px";
+                fieldsetObject[i].style.display = "inline-block";
+            }
+
             $.ajax({
                 type: "POST",
                 url: "{{ endpoint }}/accounts/{{ account_id }}/sources/{{ source_id }}/take_survey?survey_template_id={{ survey_template_id }}",
@@ -65,14 +114,16 @@
     <li class="breadcrumb-item active" aria-current="page">Participant Survey</li>
 {% endblock %}
 {% block content %}
+    <div id="form-progress">Progress</div>
     <div class="panel panel-default">
         <div class="panel-body">
             <form id="survey_form" name="survey_form">
                 <vue-form-generator :schema="schema" :model="model" :options="formOptions"></vue-form-generator>
             </form>
         </div>
+	<input type="button" id="survey-nav-button-previous" class="survey-nav-button" value="&lt;&lt; Previous Section" onClick="changePage('previous');">
+	<input type="button" id="survey-nav-button-next" class="survey-nav-button" value="Next Section &gt;&gt;" onClick="changePage('next');">
     </div>
-
     <script type="text/javascript">
         var survey_model = {};
         var survey_schema= {{survey_schema|tojson}};
@@ -94,10 +145,85 @@
             type: "submit",
             validateBeforeSubmit: true,
             onSubmit: function(){
-                $("input").prop('disabled', true);
-                return postSurvey();
+                if(form_submitted == 0) {
+                    confirm_submit = confirm("Please note: Once you've submitted this survey, you'll be unable to edit your answers. If you'd like to review or change any of your responses, please press the Cancel button. Otherwise, press OK to submit your responses.");
+                    form_submitted = 1;
+                } else {
+                    confirm_submit = true;
+                }
+
+                if(confirm_submit == true) {
+                    $("input").prop('disabled', true);
+                    return postSurvey();
+                }
             }
         });
+
+        var active_section = 0;
+
+        function paginateForm() {
+            fieldsetObject = document.getElementsByTagName("fieldset");
+
+            if(fieldsetObject.length <= 1) {
+                document.getElementById("survey-nav-button-next").style.display = "none";
+            } else {
+                document.getElementById("form-progress").style.display = "block";
+                document.getElementById("form-progress").innerHTML = "Step 1 of " + fieldsetObject.length + " - 0% Complete";
+                for(i=1; i<fieldsetObject.length; i++) {
+                    fieldsetObject[i].style.display = "none";
+                }
+                document.getElementById("survey-nav-button-next").style.display = "inline-block";
+            }
+        }
+
+        function changePage(direction) {
+            if(direction == "next") {
+                new_active_section = active_section + 1;
+            } else {
+                new_active_section = active_section - 1;
+            }
+            display_active_section = new_active_section+1;
+
+            fieldsetObject = document.getElementsByTagName("fieldset");
+
+            fieldsetObject[active_section].style.display = "none";
+            document.getElementById("form-progress").innerHTML = "Step " + display_active_section + " of " + fieldsetObject.length + " - " + Math.round((new_active_section/fieldsetObject.length)*100) + "% Complete";
+            fieldsetObject[new_active_section].style.display = "block";
+
+            if(new_active_section == 0) {
+                document.getElementById("survey-nav-button-previous").style.display = "none";
+            } else {
+                document.getElementById("survey-nav-button-previous").style.display = "inline-block";
+            }
+            if(new_active_section == (fieldsetObject.length-1)) {
+                document.getElementById("survey-nav-button-next").style.display = "none";
+            } else {
+                document.getElementById("survey-nav-button-next").style.display = "inline-block";
+            }
+
+            window.scrollTo(0,0);
+            active_section = new_active_section;
+        }
+
+
+        function nextPage() {
+            new_active_section = active_section + 1;
+            display_active_section = new_active_section+1;
+
+            fieldsetObject = document.getElementsByTagName("fieldset");
+
+            fieldsetObject[active_section].style.display = "none";
+            document.getElementById("form-progress").innerHTML = "Step " + display_active_section + " of " + fieldsetObject.length + " - " + Math.round((new_active_section/fieldsetObject.length)*100) + "% Complete";
+            fieldsetObject[new_active_section].style.display = "block";
+            if(new_active_section == (fieldsetObject.length-1)) {
+                document.getElementById("survey-nav-button-next").style.display = "none";
+            }
+            window.scrollTo(0,0);
+            active_section = new_active_section;
+        }
+
+        $(paginateForm);
     </script>
     <script type="text/javascript" src="/static/vue_survey_form.js"></script>
 {% endblock %}
+

--- a/microsetta_interface/templates/survey.jinja2
+++ b/microsetta_interface/templates/survey.jinja2
@@ -49,10 +49,10 @@
         var form_submitted = 0;
 
         function postSurvey() {
-            fieldsetObject = document.getElementsByTagName("fieldset");
+            let fieldsetObject = document.getElementsByTagName("fieldset");
 
-            // workaround to make the first six sections of the survey visible to the DOM so they submit, but hidden to the user
-            for(i=1; i<(fieldsetObject.length-1); i++) {
+            // workaround to make the earlier sections of the survey visible to the DOM so they submit, but hidden to the user
+            for(let i=1; i<(fieldsetObject.length-1); i++) {
                 fieldsetObject[i].style.position = "absolute";
                 fieldsetObject[i].style.top = "-9999px";
                 fieldsetObject[i].style.left = "-9999px";
@@ -145,14 +145,15 @@
             type: "submit",
             validateBeforeSubmit: true,
             onSubmit: function(){
-                if(form_submitted == 0) {
-                    confirm_submit = confirm("Please note: Once you've submitted this survey, you'll be unable to edit your answers. If you'd like to review or change any of your responses, please press the Cancel button. Otherwise, press OK to submit your responses.");
+                let confirm_submit = false;
+                if(form_submitted === 0) {
+                    confirm_submit = confirm("Please note: Once you've submitted this survey, you'll be unable to edit your answers.\r\n\r\nIf you'd like to review or change any of your responses, please press the Cancel button. Otherwise, press OK to submit your responses.\r\n\r\nThis warning will only appear once.");
                     form_submitted = 1;
                 } else {
                     confirm_submit = true;
                 }
 
-                if(confirm_submit == true) {
+                if(confirm_submit === true) {
                     $("input").prop('disabled', true);
                     return postSurvey();
                 }
@@ -162,14 +163,14 @@
         var active_section = 0;
 
         function paginateForm() {
-            fieldsetObject = document.getElementsByTagName("fieldset");
+            let fieldsetObject = document.getElementsByTagName("fieldset");
 
             if(fieldsetObject.length <= 1) {
                 document.getElementById("survey-nav-button-next").style.display = "none";
             } else {
                 document.getElementById("form-progress").style.display = "block";
                 document.getElementById("form-progress").innerHTML = "Step 1 of " + fieldsetObject.length + " - 0% Complete";
-                for(i=1; i<fieldsetObject.length; i++) {
+                for(let i=1; i<fieldsetObject.length; i++) {
                     fieldsetObject[i].style.display = "none";
                 }
                 document.getElementById("survey-nav-button-next").style.display = "inline-block";
@@ -177,25 +178,26 @@
         }
 
         function changePage(direction) {
-            if(direction == "next") {
+            let fieldsetObject = document.getElementsByTagName("fieldset");
+            let new_active_section = 0;
+
+            if(direction === "next") {
                 new_active_section = active_section + 1;
             } else {
                 new_active_section = active_section - 1;
             }
-            display_active_section = new_active_section+1;
-
-            fieldsetObject = document.getElementsByTagName("fieldset");
+            let display_active_section = new_active_section+1;
 
             fieldsetObject[active_section].style.display = "none";
             document.getElementById("form-progress").innerHTML = "Step " + display_active_section + " of " + fieldsetObject.length + " - " + Math.round((new_active_section/fieldsetObject.length)*100) + "% Complete";
             fieldsetObject[new_active_section].style.display = "block";
 
-            if(new_active_section == 0) {
+            if(new_active_section === 0) {
                 document.getElementById("survey-nav-button-previous").style.display = "none";
             } else {
                 document.getElementById("survey-nav-button-previous").style.display = "inline-block";
             }
-            if(new_active_section == (fieldsetObject.length-1)) {
+            if(new_active_section === (fieldsetObject.length-1)) {
                 document.getElementById("survey-nav-button-next").style.display = "none";
             } else {
                 document.getElementById("survey-nav-button-next").style.display = "inline-block";

--- a/microsetta_interface/templates/survey.jinja2
+++ b/microsetta_interface/templates/survey.jinja2
@@ -205,23 +205,6 @@
             active_section = new_active_section;
         }
 
-
-        function nextPage() {
-            new_active_section = active_section + 1;
-            display_active_section = new_active_section+1;
-
-            fieldsetObject = document.getElementsByTagName("fieldset");
-
-            fieldsetObject[active_section].style.display = "none";
-            document.getElementById("form-progress").innerHTML = "Step " + display_active_section + " of " + fieldsetObject.length + " - " + Math.round((new_active_section/fieldsetObject.length)*100) + "% Complete";
-            fieldsetObject[new_active_section].style.display = "block";
-            if(new_active_section == (fieldsetObject.length-1)) {
-                document.getElementById("survey-nav-button-next").style.display = "none";
-            }
-            window.scrollTo(0,0);
-            active_section = new_active_section;
-        }
-
         $(paginateForm);
     </script>
     <script type="text/javascript" src="/static/vue_survey_form.js"></script>


### PR DESCRIPTION
1) On new_participant.jinja2, there are two groups of changes:
1a) Not all fields that are required were actually shown as required to the user - I standardized that
1b) The asterisk for required fields was breaking onto a new line - I formatted it to be red and show up on the same line with cleaned-up visuals

2) On survey.jinja2:
2a) I paginated the form by field group
2b) Added buttons for Previous & Next Section
2c) Added a progress bar to the top of the screen
2d) Add a one-time confirm on submit since responses can't be edited
2e) Made some font weight and size changes to decrease the wall-of-text effect

(note, depends on biocore/microsetta-private-api#315)