### PR TITLE
Adds messages.pot and first usages of gettext

### DIFF
--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,4 @@
+[python: **.py]
+[jinja2: **/templates/**.html]
+extensions=jinja2.ext.autoescape,jinja2.ext.with_
+

--- a/messages.pot
+++ b/messages.pot
@@ -1,0 +1,101 @@
+# Translations template for PROJECT.
+# Copyright (C) 2021 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2021-05-04 17:09-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.0\n"
+
+#: microsetta_interface/implementation.py:379
+msgid "Unable to validate the kit name; please reload the page."
+msgstr ""
+
+#: microsetta_interface/implementation.py:398
+msgid ""
+"The provided kit id is not valid or has already been used; please re-"
+"check your entry."
+msgstr ""
+
+#: microsetta_interface/implementation.py:1012
+msgid "Blood (skin prick)"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1013
+msgid "Saliva"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1014
+msgid "Stool"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1015
+msgid "Mouth"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1016
+msgid "Nares"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1017
+msgid "Nasal mucus"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1018
+msgid "Right hand"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1019
+msgid "Left hand"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1020
+msgid "Forehead"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1021
+msgid "Torso"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1022
+msgid "Right leg"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1023
+msgid "Left leg"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1024
+msgid "Vaginal mucus"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1025
+msgid "Tears"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1026
+msgid "Ear wax"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1027
+msgid "Hair"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1028
+msgid "Fur"
+msgstr ""
+
+#: microsetta_interface/implementation.py:1253
+msgid "Unable to validate Activation Code at this time"
+msgstr ""
+

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -1,7 +1,7 @@
-from gettext import gettext
 
 import flask
 import flask_babel
+from flask_babel import gettext
 from flask import render_template, session, redirect, make_response
 import jwt
 import requests
@@ -1008,6 +1008,8 @@ def get_update_sample(*, account_id=None, source_id=None, sample_id=None):
                         "Forehead", "Torso", "Right leg", "Left leg",
                         "Vaginal mucus", "Tears", "Ear wax", "Hair", "Fur"]
         # babel scraping doesn't understand anything but constant strings.
+        # do not collapse this into a for loop unless you can verify
+        # that the POT file is correctly updated.
         sample_site_translations = [
             gettext("Blood (skin prick)"),
             gettext("Saliva"),

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -1130,17 +1130,18 @@ def get_sample_results(*, account_id=None, source_id=None, sample_id=None):
     if has_error:
         return sample_output
 
-    return _render_with_defaults('sample_results.jinja2',
-                                 account_id=account_id,
-                                 source_id=source_id,
-                                 sample=sample_output,
-                                 source_name=source_output['source_name'],
-                                 taxonomy=SERVER_CONFIG["taxonomy_resource"],
-                                 alpha_metric=SERVER_CONFIG["alpha_metric"],
-                                 beta_metric=SERVER_CONFIG["beta_metric"],
-                                 barcode_prefix=SERVER_CONFIG["barcode_prefix"],
-                                 show_breadcrumbs=True
-                                 )
+    return _render_with_defaults(
+        'sample_results.jinja2',
+        account_id=account_id,
+        source_id=source_id,
+        sample=sample_output,
+        source_name=source_output['source_name'],
+        taxonomy=SERVER_CONFIG["taxonomy_resource"],
+        alpha_metric=SERVER_CONFIG["alpha_metric"],
+        beta_metric=SERVER_CONFIG["beta_metric"],
+        barcode_prefix=SERVER_CONFIG["barcode_prefix"],
+        show_breadcrumbs=True
+        )
 
 
 # WARNING: this endpoint is NOT authenticated
@@ -1156,17 +1157,18 @@ def get_sample_results_experimental():
                      'sample_remove_locked': False,
                      'sample_site': 'Stool',
                      'source_id': 'NA'}
-    return _render_with_defaults('new_results_page.jinja2',
-                                 account_id='NA',
-                                 source_id='NA',
-                                 sample=sample_output,
-                                 source_name='NA',
-                                 taxonomy=SERVER_CONFIG["taxonomy_resource"],
-                                 alpha_metric=SERVER_CONFIG["alpha_metric"],
-                                 beta_metric=SERVER_CONFIG["beta_metric"],
-                                 barcode_prefix=SERVER_CONFIG["barcode_prefix"],
-                                 show_breadcrumbs=False
-                                 )
+    return _render_with_defaults(
+        'new_results_page.jinja2',
+        account_id='NA',
+        source_id='NA',
+        sample=sample_output,
+        source_name='NA',
+        taxonomy=SERVER_CONFIG["taxonomy_resource"],
+        alpha_metric=SERVER_CONFIG["alpha_metric"],
+        beta_metric=SERVER_CONFIG["beta_metric"],
+        barcode_prefix=SERVER_CONFIG["barcode_prefix"],
+        show_breadcrumbs=False
+    )
 
 
 @prerequisite([SOURCE_PREREQS_MET])

--- a/microsetta_interface/server.py
+++ b/microsetta_interface/server.py
@@ -2,8 +2,6 @@
 import secrets
 import logging
 
-import babel
-
 from microsetta_interface.config_manager import SERVER_CONFIG
 from flask import jsonify, g, request
 from werkzeug.utils import redirect
@@ -79,6 +77,10 @@ def run(app):
     )
 
 
+app = build_app()
+babel = Babel(app.app)
+
+
 @babel.localeselector
 def get_locale():
     # OKAY, So, we can use this snippet from https://flask-babel.tkte.ch/
@@ -115,10 +117,6 @@ def get_timezone():
     user = getattr(g, 'user', None)
     if user is not None:
         return user.timezone
-
-
-app = build_app()
-babel = Babel(app.app)
 
 
 # If we're running in stand alone mode, run the application

--- a/microsetta_interface/server.py
+++ b/microsetta_interface/server.py
@@ -109,11 +109,13 @@ def get_locale():
     # TODO: We update this as we add support for new languages
     return request.accept_languages.best_match(['en', 'es'])
 
+
 @babel.timezoneselector
 def get_timezone():
     user = getattr(g, 'user', None)
     if user is not None:
         return user.timezone
+
 
 app = build_app()
 babel = Babel(app.app)

--- a/microsetta_interface/server.py
+++ b/microsetta_interface/server.py
@@ -2,8 +2,10 @@
 import secrets
 import logging
 
+import babel
+
 from microsetta_interface.config_manager import SERVER_CONFIG
-from flask import jsonify
+from flask import jsonify, g, request
 from werkzeug.utils import redirect
 
 import connexion
@@ -76,6 +78,42 @@ def run(app):
         ssl_context=ssl_context
     )
 
+
+@babel.localeselector
+def get_locale():
+    # OKAY, So, we can use this snippet from https://flask-babel.tkte.ch/
+    # to pick the user locale, or we can do something else.
+    # User locale could come from:
+    #   user preferences in microsetta-interface (EXPLICIT)
+    #       Doesn't work on login page,
+    #       all requests must have access to session to pull this
+    #       requires special handoff to external services like
+    #           vioscreen/authrocket
+    #   user accept header (IMPLICIT)
+    #       Generally set by user in browser,
+    #       or more likely configured at user's OS
+    #   exact url (EXPLICIT)
+    #       microsetta-rest.ucsd.mx
+    #       microsetta-rest.ucsd.edu/MX/resourcename
+    #       microsetta-rest.ucsd.edu/blahblah?lang=es-MX
+    # Best practice seems to be to use whatever user explicitly specified first
+    # then if nothing is available, fall back to the user accept header.
+
+    # TODO: We could move these settings into our SESSION cookie, but
+    #  all the flask-babel examples seem to use this 'user' pattern, so
+    #  may be standard practice to leave it exactly as is in their example.
+    user = getattr(g, 'user', None)
+    if user is not None:
+        return user.locale
+
+    # TODO: We update this as we add support for new languages
+    return request.accept_languages.best_match(['en', 'es'])
+
+@babel.timezoneselector
+def get_timezone():
+    user = getattr(g, 'user', None)
+    if user is not None:
+        return user.timezone
 
 app = build_app()
 babel = Babel(app.app)

--- a/microsetta_interface/templates/sample.jinja2
+++ b/microsetta_interface/templates/sample.jinja2
@@ -166,8 +166,10 @@
                         {% if not sample.sample_site %}
                         <option disabled selected value> -- Select a sample type -- </option>
                         {% endif %}
-                        {% for site in sample_sites %}
-                        <option value="{{site}}" {% if sample.sample_site == site %}selected {% endif %}>{{site}}</option>
+                        {% for i in range(sample_sites| length) %}
+                            {% set site=sample_sites[i] %}
+                            {% set site_text=sample_sites_text[i] %}
+                        <option value="{{site}}" {% if sample.sample_site == site %}selected {% endif %}>{{site_text}}</option>
                         {% endfor %}
                       </select>
                     </div>


### PR DESCRIPTION
First pass over implementation.py to add support for gettext and properly format dates.  

Added a super basic babel config, will need to add to it to support javascript, but should work for python and jinja2.  

To regenerate messages.pot (after you add gettext calls to python or jinja2 templates):
cd to root directory of checkout
pybabel extract -F babel.cfg -o messages.pot .

To check if your new strings made it past the extract call, 
cat messages.pot and look for your strings.  