### PR TITLE
Represent country code, allow for selection of countries outside of U…

### DIFF
--- a/microsetta_interface/static/js/country_state_list.js
+++ b/microsetta_interface/static/js/country_state_list.js
@@ -1,769 +1,4801 @@
 // Forked from Ebaranov's country/state json with corrections
 // See https://gist.github.com/ebaranov/41bf38fdb1a2cb19a781
 // and https://gist.githubusercontent.com/dhakim87/365826ca4810f3b49fd73e26f498c8c0/raw/9cb6730b4612fb80861b695a733e512a351dae93/country_list.js
+//
+// US / UK / MX are placed first as these countries we have active engagement,
+// so prioritizing them for ordering
 COUNTRIES_LIST = [
-    {
-      "country": "Afghanistan",
-      "states": ["Badakhshan", "Badghis", "Baghlan", "Balkh", "Bamian", "Daykondi", "Farah", "Faryab", "Ghazni", "Ghowr", "Helmand", "Herat", "Jowzjan", "Kabul", "Kandahar", "Kapisa", "Khost", "Konar", "Kondoz", "Laghman", "Lowgar", "Nangarhar", "Nimruz", "Nurestan", "Oruzgan", "Paktia", "Paktika", "Panjshir", "Parvan", "Samangan", "Sar-e Pol", "Takhar", "Vardak", "Zabol"]
-    },
-    {
-      "country": "Albania",
-      "states": ["Berat", "Dibres", "Durres", "Elbasan", "Fier", "Gjirokastre", "Korce", "Kukes", "Lezhe", "Shkoder", "Tirane", "Vlore"]
-    },
-    {
-      "country": "Algeria",
-      "states": ["Adrar", "Ain Defla", "Ain Temouchent", "Alger", "Annaba", "Batna", "Bechar", "Bejaia", "Biskra", "Blida", "Bordj Bou Arreridj", "Bouira", "Boumerdes", "Chlef", "Constantine", "Djelfa", "El Bayadh", "El Oued", "El Tarf", "Ghardaia", "Guelma", "Illizi", "Jijel", "Khenchela", "Laghouat", "Muaskar", "Medea", "Mila", "Mostaganem", "M'Sila", "Naama", "Oran", "Ouargla", "Oum el Bouaghi", "Relizane", "Saida", "Setif", "Sidi Bel Abbes", "Skikda", "Souk Ahras", "Tamanghasset", "Tebessa", "Tiaret", "Tindouf", "Tipaza", "Tissemsilt", "Tizi Ouzou", "Tlemcen"]
-    },
-    {
-      "country": "Andorra",
-      "states": ["Andorra la Vella", "Canillo", "Encamp", "Escaldes-Engordany", "La Massana", "Ordino", "Sant Julia de Loria"]
-    },
-    {
-      "country": "Angola",
-      "states": ["Bengo", "Benguela", "Bie", "Cabinda", "Cuando Cubango", "Cuanza Norte", "Cuanza Sul", "Cunene", "Huambo", "Huila", "Luanda", "Lunda Norte", "Lunda Sul", "Malanje", "Moxico", "Namibe", "Uige", "Zaire"]
-    },
-    {
-      "country": "Antarctica",
-      "states": []
-    },
-    {
-      "country": "Antigua and Barbuda",
-      "states": ["Barbuda", "Redonda", "Saint George", "Saint John", "Saint Mary", "Saint Paul", "Saint Peter", "Saint Philip"]
-    },
-    {
-      "country": "Argentina",
-      "states": ["Buenos Aires", "Buenos Aires Capital", "Catamarca", "Chaco", "Chubut", "Cordoba", "Corrientes", "Entre Rios", "Formosa", "Jujuy", "La Pampa", "La Rioja", "Mendoza", "Misiones", "Neuquen", "Rio Negro", "Salta", "San Juan", "San Luis", "Santa Cruz", "Santa Fe", "Santiago del Estero", "Tierra del Fuego", "Tucuman"]
-    },
-    {
-      "country": "Armenia",
-      "states": ["Aragatsotn", "Ararat", "Armavir", "Geghark'unik'", "Kotayk'", "Lorri", "Shirak", "Syunik'", "Tavush", "Vayots' Dzor", "Yerevan"]
-    },
-    {
-      "country": "Australia",
-      "states": ["Australian Capital Territory", "New South Wales", "Northern Territory", "Queensland", "South Australia", "Tasmania", "Victoria", "Western Australia"]
-    },
-    {
-      "country": "Austria",
-      "states": ["Burgenland", "Kaernten", "Niederoesterreich", "Oberoesterreich", "Salzburg", "Steiermark", "Tirol", "Vorarlberg", "Wien"]
-    },
-    {
-      "country": "Azerbaijan",
-      "states": ["Abseron Rayonu", "Agcabadi Rayonu", "Agdam Rayonu", "Agdas Rayonu", "Agstafa Rayonu", "Agsu Rayonu", "Astara Rayonu", "Balakan Rayonu", "Barda Rayonu", "Beylaqan Rayonu", "Bilasuvar Rayonu", "Cabrayil Rayonu", "Calilabad Rayonu", "Daskasan Rayonu", "Davaci Rayonu", "Fuzuli Rayonu", "Gadabay Rayonu", "Goranboy Rayonu", "Goycay Rayonu", "Haciqabul Rayonu", "Imisli Rayonu", "Ismayilli Rayonu", "Kalbacar Rayonu", "Kurdamir Rayonu", "Lacin Rayonu", "Lankaran Rayonu", "Lerik Rayonu", "Masalli Rayonu", "Neftcala Rayonu", "Oguz Rayonu", "Qabala Rayonu", "Qax Rayonu", "Qazax Rayonu", "Qobustan Rayonu", "Quba Rayonu", "Qubadli Rayonu", "Qusar Rayonu", "Saatli Rayonu", "Sabirabad Rayonu", "Saki Rayonu", "Salyan Rayonu", "Samaxi Rayonu", "Samkir Rayonu", "Samux Rayonu", "Siyazan Rayonu", "Susa Rayonu", "Tartar Rayonu", "Tovuz Rayonu", "Ucar Rayonu", "Xacmaz Rayonu", "Xanlar Rayonu", "Xizi Rayonu", "Xocali Rayonu", "Xocavand Rayonu", "Yardimli Rayonu", "Yevlax Rayonu", "Zangilan Rayonu", "Zaqatala Rayonu", "Zardab Rayonu", "Ali Bayramli Sahari", "Baki Sahari", "Ganca Sahari", "Lankaran Sahari", "Mingacevir Sahari", "Naftalan Sahari", "Saki Sahari", "Sumqayit Sahari", "Susa Sahari", "Xankandi Sahari", "Yevlax Sahari", "Naxcivan Muxtar"]
-    },
-    {
-      "country": "Bahamas",
-      "states": ["Acklins and Crooked Islands", "Bimini", "Cat Island", "Exuma", "Freeport", "Fresh Creek", "Governor's Harbour", "Green Turtle Cay", "Harbour Island", "High Rock", "Inagua", "Kemps Bay", "Long Island", "Marsh Harbour", "Mayaguana", "New Providence", "Nichollstown and Berry Islands", "Ragged Island", "Rock Sound", "Sandy Point", "San Salvador and Rum Cay"]
-    },
-    {
-      "country": "Bahrain",
-      "states": ["Al Hadd", "Al Manamah", "Al Mintaqah al Gharbiyah", "Al Mintaqah al Wusta", "Al Mintaqah ash Shamaliyah", "Al Muharraq", "Ar Rifa' wa al Mintaqah al Janubiyah", "Jidd Hafs", "Madinat Hamad", "Madinat 'Isa", "Juzur Hawar", "Sitrah"]
-    },
-    {
-      "country": "Bangladesh",
-      "states": ["Barisal", "Chittagong", "Dhaka", "Khulna", "Rajshahi", "Sylhet"]
-    },
-    {
-      "country": "Barbados",
-      "states": ["Christ Church", "Saint Andrew", "Saint George", "Saint James", "Saint John", "Saint Joseph", "Saint Lucy", "Saint Michael", "Saint Peter", "Saint Philip", "Saint Thomas"]
-    },
-    {
-      "country": "Belarus",
-      "states": ["Brest", "Homyel", "Horad Minsk", "Hrodna", "Mahilyow", "Minsk", "Vitsyebsk"]
-    },
-    {
-      "country": "Belgium",
-      "states": ["Antwerpen", "Brabant Wallon", "Brussels", "Flanders", "Hainaut", "Liege", "Limburg", "Luxembourg", "Namur", "Oost-Vlaanderen", "Vlaams-Brabant", "Wallonia", "West-Vlaanderen"]
-    },
-    {
-      "country": "Belize",
-      "states": ["Belize", "Cayo", "Corozal", "Orange Walk", "Stann Creek", "Toledo"]
-    },
-    {
-      "country": "Benin",
-      "states": ["Alibori", "Atakora", "Atlantique", "Borgou", "Collines", "Donga", "Kouffo", "Littoral", "Mono", "Oueme", "Plateau", "Zou"]
-    },
-    {
-      "country": "Bermuda",
-      "states": ["Devonshire", "Hamilton", "Hamilton", "Paget", "Pembroke", "Saint George", "Saint George's", "Sandys", "Smith's", "Southampton", "Warwick"]
-    },
-    {
-      "country": "Bhutan",
-      "states": ["Bumthang", "Chukha", "Dagana", "Gasa", "Haa", "Lhuntse", "Mongar", "Paro", "Pemagatshel", "Punakha", "Samdrup Jongkhar", "Samtse", "Sarpang", "Thimphu", "Trashigang", "Trashiyangste", "Trongsa", "Tsirang", "Wangdue Phodrang", "Zhemgang"]
-    },
-    {
-      "country": "Bolivia",
-      "states": ["Chuquisaca", "Cochabamba", "Beni", "La Paz", "Oruro", "Pando", "Potosi", "Santa Cruz", "Tarija"]
-    },
-    {
-      "country": "Bosnia and Herzegovina",
-      "states": ["Una-Sana [Federation]", "Posavina [Federation]", "Tuzla [Federation]", "Zenica-Doboj [Federation]", "Bosnian Podrinje [Federation]", "Central Bosnia [Federation]", "Herzegovina-Neretva [Federation]", "West Herzegovina [Federation]", "Sarajevo [Federation]", " West Bosnia [Federation]", "Banja Luka [RS]", "Bijeljina [RS]", "Doboj [RS]", "Fo?a [RS]", "Sarajevo-Romanija [RS]", "Trebinje [RS]", "Vlasenica [RS]"]
-    },
-    {
-      "country": "Botswana",
-      "states": ["Central", "Ghanzi", "Kgalagadi", "Kgatleng", "Kweneng", "North East", "North West", "South East", "Southern"]
-    },
-    {
-      "country": "Brazil",
-      "states": ["Acre", "Alagoas", "Amapa", "Amazonas", "Bahia", "Ceara", "Distrito Federal", "Espirito Santo", "Goias", "Maranhao", "Mato Grosso", "Mato Grosso do Sul", "Minas Gerais", "Para", "Paraiba", "Parana", "Pernambuco", "Piaui", "Rio de Janeiro", "Rio Grande do Norte", "Rio Grande do Sul", "Rondonia", "Roraima", "Santa Catarina", "Sao Paulo", "Sergipe", "Tocantins"]
-    },
-    {
-      "country": "Brunei",
-      "states": ["Belait", "Brunei and Muara", "Temburong", "Tutong"]
-    },
-    {
-      "country": "Bulgaria",
-      "states": ["Blagoevgrad", "Burgas", "Dobrich", "Gabrovo", "Khaskovo", "Kurdzhali", "Kyustendil", "Lovech", "Montana", "Pazardzhik", "Pernik", "Pleven", "Plovdiv", "Razgrad", "Ruse", "Shumen", "Silistra", "Sliven", "Smolyan", "Sofiya", "Sofiya-Grad", "Stara Zagora", "Turgovishte", "Varna", "Veliko Turnovo", "Vidin", "Vratsa", "Yambol"]
-    },
-    {
-      "country": "Burkina Faso",
-      "states": ["Bale", "Bam", "Banwa", "Bazega", "Bougouriba", "Boulgou", "Boulkiemde", "Comoe", "Ganzourgou", "Gnagna", "Gourma", "Houet", "Ioba", "Kadiogo", "Kenedougou", "Komondjari", "Kompienga", "Kossi", "Koulpelogo", "Kouritenga", "Kourweogo", "Leraba", "Loroum", "Mouhoun", "Namentenga", "Nahouri", "Nayala", "Noumbiel", "Oubritenga", "Oudalan", "Passore", "Poni", "Sanguie", "Sanmatenga", "Seno", "Sissili", "Soum", "Sourou", "Tapoa", "Tuy", "Yagha", "Yatenga", "Ziro", "Zondoma", "Zoundweogo"]
-    },
-    {
-      "country": "Burma",
-      "states": ["Ayeyarwady", "Bago", "Magway", "Mandalay", "Sagaing", "Tanintharyi", "Yangon", "Chin State", "Kachin State", "Kayin State", "Kayah State", "Mon State", "Rakhine State", "Shan State"]
-    },
-    {
-      "country": "Burundi",
-      "states": ["Bubanza", "Bujumbura Mairie", "Bujumbura Rural", "Bururi", "Cankuzo", "Cibitoke", "Gitega", "Karuzi", "Kayanza", "Kirundo", "Makamba", "Muramvya", "Muyinga", "Mwaro", "Ngozi", "Rutana", "Ruyigi"]
-    },
-    {
-      "country": "Cambodia",
-      "states": ["Banteay Mean Chey", "Batdambang", "Kampong Cham", "Kampong Chhnang", "Kampong Spoe", "Kampong Thum", "Kampot", "Kandal", "Koh Kong", "Kracheh", "Mondol Kiri", "Otdar Mean Chey", "Pouthisat", "Preah Vihear", "Prey Veng", "Rotanakir", "Siem Reab", "Stoeng Treng", "Svay Rieng", "Takao", "Keb", "Pailin", "Phnom Penh", "Preah Seihanu"]
-    },
-    {
-      "country": "Cameroon",
-      "states": ["Adamaoua", "Centre", "Est", "Extreme-Nord", "Littoral", "Nord", "Nord-Ouest", "Ouest", "Sud", "Sud-Ouest"]
-    },
-    {
-      "country": "Canada",
-      "states": ["Alberta", "British Columbia", "Manitoba", "New Brunswick", "Newfoundland and Labrador", "Northwest Territories", "Nova Scotia", "Nunavut", "Ontario", "Prince Edward Island", "Quebec", "Saskatchewan", "Yukon Territory"]
-    },
-    {
-      "country": "Cape Verde",
-      "states": []
-    },
-    {
-      "country": "Central African Republic",
-      "states": ["Bamingui-Bangoran", "Bangui", "Basse-Kotto", "Haute-Kotto", "Haut-Mbomou", "Kemo", "Lobaye", "Mambere-Kadei", "Mbomou", "Nana-Grebizi", "Nana-Mambere", "Ombella-Mpoko", "Ouaka", "Ouham", "Ouham-Pende", "Sangha-Mbaere", "Vakaga"]
-    },
-    {
-      "country": "Chad",
-      "states": ["Batha", "Biltine", "Borkou-Ennedi-Tibesti", "Chari-Baguirmi", "Guéra", "Kanem", "Lac", "Logone Occidental", "Logone Oriental", "Mayo-Kebbi", "Moyen-Chari", "Ouaddaï", "Salamat", "Tandjile"]
-    },
-    {
-      "country": "Chile",
-      "states": ["Aysen", "Antofagasta", "Araucania", "Atacama", "Bio-Bio", "Coquimbo", "O'Higgins", "Los Lagos", "Magallanes y la Antartica Chilena", "Maule", "Santiago Region Metropolitana", "Tarapaca", "Valparaiso"]
-    },
-    {
-      "country": "China",
-      "states": ["Anhui", "Fujian", "Gansu", "Guangdong", "Guizhou", "Hainan", "Hebei", "Heilongjiang", "Henan", "Hubei", "Hunan", "Jiangsu", "Jiangxi", "Jilin", "Liaoning", "Qinghai", "Shaanxi", "Shandong", "Shanxi", "Sichuan", "Yunnan", "Zhejiang", "Guangxi", "Nei Mongol", "Ningxia", "Xinjiang", "Xizang (Tibet)", "Beijing", "Chongqing", "Shanghai", "Tianjin"]
-    },
-    {
-      "country": "Colombia",
-      "states": ["Amazonas", "Antioquia", "Arauca", "Atlantico", "Bogota District Capital", "Bolivar", "Boyaca", "Caldas", "Caqueta", "Casanare", "Cauca", "Cesar", "Choco", "Cordoba", "Cundinamarca", "Guainia", "Guaviare", "Huila", "La Guajira", "Magdalena", "Meta", "Narino", "Norte de Santander", "Putumayo", "Quindio", "Risaralda", "San Andres & Providencia", "Santander", "Sucre", "Tolima", "Valle del Cauca", "Vaupes", "Vichada"]
-    },
-    {
-      "country": "Comoros",
-      "states": ["Grande Comore (Njazidja)", "Anjouan (Nzwani)", "Moheli (Mwali)"]
-    },
-    {
-      "country": "Congo, Democratic Republic",
-      "states": ["Bandundu", "Bas-Congo", "Equateur", "Kasai-Occidental", "Kasai-Oriental", "Katanga", "Kinshasa", "Maniema", "Nord-Kivu", "Orientale", "Sud-Kivu"]
-    },
-    {
-      "country": "Congo, Republic of the",
-      "states": ["Bouenza", "Brazzaville", "Cuvette", "Cuvette-Ouest", "Kouilou", "Lekoumou", "Likouala", "Niari", "Plateaux", "Pool", "Sangha"]
-    },
-    {
-      "country": "Costa Rica",
-      "states": ["Alajuela", "Cartago", "Guanacaste", "Heredia", "Limon", "Puntarenas", "San Jose"]
-    },
-    {
-      "country": "Cote d'Ivoire",
-      "states": []
-    },
-    {
-      "country": "Croatia",
-      "states": ["Bjelovarsko-Bilogorska", "Brodsko-Posavska", "Dubrovacko-Neretvanska", "Istarska", "Karlovacka", "Koprivnicko-Krizevacka", "Krapinsko-Zagorska", "Licko-Senjska", "Medimurska", "Osjecko-Baranjska", "Pozesko-Slavonska", "Primorsko-Goranska", "Sibensko-Kninska", "Sisacko-Moslavacka", "Splitsko-Dalmatinska", "Varazdinska", "Viroviticko-Podravska", "Vukovarsko-Srijemska", "Zadarska", "Zagreb", "Zagrebacka"]
-    },
-    {
-      "country": "Cuba",
-      "states": ["Camaguey", "Ciego de Avila", "Cienfuegos", "Ciudad de La Habana", "Granma", "Guantanamo", "Holguin", "Isla de la Juventud", "La Habana", "Las Tunas", "Matanzas", "Pinar del Rio", "Sancti Spiritus", "Santiago de Cuba", "Villa Clara"]
-    },
-    {
-      "country": "Cyprus",
-      "states": ["Famagusta", "Kyrenia", "Larnaca", "Limassol", "Nicosia", "Paphos"]
-    },
-    {
-      "country": "Czech Republic",
-      "states": ["Jihocesky Kraj", "Jihomoravsky Kraj", "Karlovarsky Kraj", "Kralovehradecky Kraj", "Liberecky Kraj", "Moravskoslezsky Kraj", "Olomoucky Kraj", "Pardubicky Kraj", "Plzensky Kraj", "Praha", "Stredocesky Kraj", "Ustecky Kraj", "Vysocina", "Zlinsky Kraj"]
-    },
-    {
-      "country": "Denmark",
-      "states": ["Arhus", "Bornholm", "Frederiksberg", "Frederiksborg", "Fyn", "Kobenhavn", "Kobenhavns", "Nordjylland", "Ribe", "Ringkobing", "Roskilde", "Sonderjylland", "Storstrom", "Vejle", "Vestsjalland", "Viborg"]
-    },
-    {
-      "country": "Djibouti",
-      "states": ["Ali Sabih", "Dikhil", "Djibouti", "Obock", "Tadjoura"]
-    },
-    {
-      "country": "Dominica",
-      "states": ["Saint Andrew", "Saint David", "Saint George", "Saint John", "Saint Joseph", "Saint Luke", "Saint Mark", "Saint Patrick", "Saint Paul", "Saint Peter"]
-    },
-    {
-      "country": "Dominican Republic",
-      "states": ["Azua", "Baoruco", "Barahona", "Dajabon", "Distrito Nacional", "Duarte", "Elias Pina", "El Seibo", "Espaillat", "Hato Mayor", "Independencia", "La Altagracia", "La Romana", "La Vega", "Maria Trinidad Sanchez", "Monsenor Nouel", "Monte Cristi", "Monte Plata", "Pedernales", "Peravia", "Puerto Plata", "Salcedo", "Samana", "Sanchez Ramirez", "San Cristobal", "San Jose de Ocoa", "San Juan", "San Pedro de Macoris", "Santiago", "Santiago Rodriguez", "Santo Domingo", "Valverde"]
-    },
-    {
-      "country": "East Timor",
-      "states": ["Aileu", "Ainaro", "Baucau", "Bobonaro", "Cova-Lima", "Dili", "Ermera", "Lautem", "Liquica", "Manatuto", "Manufahi", "Oecussi", "Viqueque"]
-    },
-    {
-      "country": "Ecuador",
-      "states": ["Azuay", "Bolivar", "Canar", "Carchi", "Chimborazo", "Cotopaxi", "El Oro", "Esmeraldas", "Galapagos", "Guayas", "Imbabura", "Loja", "Los Rios", "Manabi", "Morona-Santiago", "Napo", "Orellana", "Pastaza", "Pichincha", "Sucumbios", "Tungurahua", "Zamora-Chinchipe"]
-    },
-    {
-      "country": "Egypt",
-      "states": ["Ad Daqahliyah", "Al Bahr al Ahmar", "Al Buhayrah", "Al Fayyum", "Al Gharbiyah", "Al Iskandariyah", "Al Isma'iliyah", "Al Jizah", "Al Minufiyah", "Al Minya", "Al Qahirah", "Al Qalyubiyah", "Al Wadi al Jadid", "Ash Sharqiyah", "As Suways", "Aswan", "Asyut", "Bani Suwayf", "Bur Sa'id", "Dumyat", "Janub Sina'", "Kafr ash Shaykh", "Matruh", "Qina", "Shamal Sina'", "Suhaj"]
-    },
-    {
-      "country": "El Salvador",
-      "states": ["Ahuachapan", "Cabanas", "Chalatenango", "Cuscatlan", "La Libertad", "La Paz", "La Union", "Morazan", "San Miguel", "San Salvador", "Santa Ana", "San Vicente", "Sonsonate", "Usulutan"]
-    },
-    {
-      "country": "Equatorial Guinea",
-      "states": ["Annobon", "Bioko Norte", "Bioko Sur", "Centro Sur", "Kie-Ntem", "Litoral", "Wele-Nzas"]
-    },
-    {
-      "country": "Eritrea",
-      "states": ["Anseba", "Debub", "Debubawi K'eyih Bahri", "Gash Barka", "Ma'akel", "Semenawi Keyih Bahri"]
-    },
-    {
-      "country": "Estonia",
-      "states": ["Harjumaa (Tallinn)", "Hiiumaa (Kardla)", "Ida-Virumaa (Johvi)", "Jarvamaa (Paide)", "Jogevamaa (Jogeva)", "Laanemaa (Haapsalu)", "Laane-Virumaa (Rakvere)", "Parnumaa (Parnu)", "Polvamaa (Polva)", "Raplamaa (Rapla)", "Saaremaa (Kuressaare)", "Tartumaa (Tartu)", "Valgamaa (Valga)", "Viljandimaa (Viljandi)", "Vorumaa (Voru)"]
-    },
-    {
-      "country": "Ethiopia",
-      "states": ["Addis Ababa", "Afar", "Amhara", "Binshangul Gumuz", "Dire Dawa", "Gambela Hizboch", "Harari", "Oromia", "Somali", "Tigray", "Southern Nations, Nationalities, and Peoples Region"]
-    },
-    {
-      "country": "Fiji",
-      "states": ["Central (Suva)", "Eastern (Levuka)", "Northern (Labasa)", "Rotuma", "Western (Lautoka)"]
-    },
-    {
-      "country": "Finland",
-      "states": ["Aland", "Etela-Suomen Laani", "Ita-Suomen Laani", "Lansi-Suomen Laani", "Lappi", "Oulun Laani"]
-    },
-    {
-      "country": "France",
-      "states": ["Alsace", "Aquitaine", "Auvergne", "Basse-Normandie", "Bourgogne", "Bretagne", "Centre", "Champagne-Ardenne", "Corse", "Franche-Comte", "Haute-Normandie", "Ile-de-France", "Languedoc-Roussillon", "Limousin", "Lorraine", "Midi-Pyrenees", "Nord-Pas-de-Calais", "Pays de la Loire", "Picardie", "Poitou-Charentes", "Provence-Alpes-Cote d'Azur", "Rhone-Alpes"]
-    },
-    {
-      "country": "Gabon",
-      "states": ["Estuaire", "Haut-Ogooue", "Moyen-Ogooue", "Ngounie", "Nyanga", "Ogooue-Ivindo", "Ogooue-Lolo", "Ogooue-Maritime", "Woleu-Ntem"]
-    },
-    {
-      "country": "Gambia",
-      "states": ["Banjul", "Central River", "Lower River", "North Bank", "Upper River", "Western"]
-    },
-    {
-      "country": "Georgia",
-      "states": []
-    },
-    {
-      "country": "Germany",
-      "states": ["Baden-Wuerttemberg", "Bayern", "Berlin", "Brandenburg", "Bremen", "Hamburg", "Hessen", "Mecklenburg-Vorpommern", "Niedersachsen", "Nordrhein-Westfalen", "Rheinland-Pfalz", "Saarland", "Sachsen", "Sachsen-Anhalt", "Schleswig-Holstein", "Thueringen"]
-    },
-    {
-      "country": "Ghana",
-      "states": ["Ashanti", "Brong-Ahafo", "Central", "Eastern", "Greater Accra", "Northern", "Upper East", "Upper West", "Volta", "Western"]
-    },
-    {
-      "country": "Greece",
-      "states": ["Agion Oros", "Achaia", "Aitolia kai Akarmania", "Argolis", "Arkadia", "Arta", "Attiki", "Chalkidiki", "Chanion", "Chios", "Dodekanisos", "Drama", "Evros", "Evrytania", "Evvoia", "Florina", "Fokidos", "Fthiotis", "Grevena", "Ileia", "Imathia", "Ioannina", "Irakleion", "Karditsa", "Kastoria", "Kavala", "Kefallinia", "Kerkyra", "Kilkis", "Korinthia", "Kozani", "Kyklades", "Lakonia", "Larisa", "Lasithi", "Lefkas", "Lesvos", "Magnisia", "Messinia", "Pella", "Pieria", "Preveza", "Rethynnis", "Rodopi", "Samos", "Serrai", "Thesprotia", "Thessaloniki", "Trikala", "Voiotia", "Xanthi", "Zakynthos"]
-    },
-    {
-      "country": "Greenland",
-      "states": ["Avannaa (Nordgronland)", "Tunu (Ostgronland)", "Kitaa (Vestgronland)"]
-    },
-    {
-      "country": "Grenada",
-      "states": ["Carriacou and Petit Martinique", "Saint Andrew", "Saint David", "Saint George", "Saint John", "Saint Mark", "Saint Patrick"]
-    },
-    {
-      "country": "Guatemala",
-      "states": ["Alta Verapaz", "Baja Verapaz", "Chimaltenango", "Chiquimula", "El Progreso", "Escuintla", "Guatemala", "Huehuetenango", "Izabal", "Jalapa", "Jutiapa", "Peten", "Quetzaltenango", "Quiche", "Retalhuleu", "Sacatepequez", "San Marcos", "Santa Rosa", "Solola", "Suchitepequez", "Totonicapan", "Zacapa"]
-    },
-    {
-      "country": "Guinea",
-      "states": ["Beyla", "Boffa", "Boke", "Conakry", "Coyah", "Dabola", "Dalaba", "Dinguiraye", "Dubreka", "Faranah", "Forecariah", "Fria", "Gaoual", "Gueckedou", "Kankan", "Kerouane", "Kindia", "Kissidougou", "Koubia", "Koundara", "Kouroussa", "Labe", "Lelouma", "Lola", "Macenta", "Mali", "Mamou", "Mandiana", "Nzerekore", "Pita", "Siguiri", "Telimele", "Tougue", "Yomou"]
-    },
-    {
-      "country": "Guinea-Bissau",
-      "states": ["Bafata", "Biombo", "Bissau", "Bolama", "Cacheu", "Gabu", "Oio", "Quinara", "Tombali"]
-    },
-    {
-      "country": "Guyana",
-      "states": ["Barima-Waini", "Cuyuni-Mazaruni", "Demerara-Mahaica", "East Berbice-Corentyne", "Essequibo Islands-West Demerara", "Mahaica-Berbice", "Pomeroon-Supenaam", "Potaro-Siparuni", "Upper Demerara-Berbice", "Upper Takutu-Upper Essequibo"]
-    },
-    {
-      "country": "Haiti",
-      "states": ["Artibonite", "Centre", "Grand 'Anse", "Nord", "Nord-Est", "Nord-Ouest", "Ouest", "Sud", "Sud-Est"]
-    },
-    {
-      "country": "Honduras",
-      "states": ["Atlantida", "Choluteca", "Colon", "Comayagua", "Copan", "Cortes", "El Paraiso", "Francisco Morazan", "Gracias a Dios", "Intibuca", "Islas de la Bahia", "La Paz", "Lempira", "Ocotepeque", "Olancho", "Santa Barbara", "Valle", "Yoro"]
-    },
-    {
-      "country": "Hong Kong",
-      "states": ["Yuen Long District","Tsuen Wan District","Tai Po District","Sai Kung District","Islands District","Central and Western District","Wan Chai","Eastern","Southern","North","Yau Tsim Mong","Sham Shui Po","Kowloon City","Wong Tai Sin","Kwun Tong","Kwai Tsing","Tuen Mun","Sha Tin"]
-    },
-    {
-      "country": "Hungary",
-      "states": ["Bacs-Kiskun", "Baranya", "Bekes", "Borsod-Abauj-Zemplen", "Csongrad", "Fejer", "Gyor-Moson-Sopron", "Hajdu-Bihar", "Heves", "Jasz-Nagykun-Szolnok", "Komarom-Esztergom", "Nograd", "Pest", "Somogy", "Szabolcs-Szatmar-Bereg", "Tolna", "Vas", "Veszprem", "Zala"]
-    },
-    {
-      "country": "Iceland",
-      "states": ["Austurland", "Hofudhborgarsvaedhi", "Nordhurland Eystra", "Nordhurland Vestra", "Sudhurland", "Sudhurnes", "Vestfirdhir", "Vesturland"]
-    },
-    {
-    "country": "India",
-    "states": ["Andaman and Nicobar Islands", "Andhra Pradesh", "Arunachal Pradesh", "Assam", "Bihar", "Chandigarh", "Chhattisgarh", "Dadra and Nagar Haveli", "Daman and Diu", "Delhi", "Goa", "Gujarat", "Haryana", "Himachal Pradesh", "Jammu and Kashmir", "Jharkhand", "Karnataka", "Kerala", "Ladakh", "Lakshadweep", "Madhya Pradesh", "Maharashtra", "Manipur", "Meghalaya", "Mizoram", "Nagaland", "Orissa", "Pondicherry", "Punjab", "Rajasthan", "Sikkim", "Tamil Nadu", "Telangana", "Tripura", "Uttaranchal", "Uttar Pradesh", "West Bengal"]
-    },
-    {
-      "country": "Indonesia",
-      "states": ["Aceh", "Bali", "Banten", "Bengkulu", "Gorontalo", "Irian Jaya Barat", "Jakarta Raya", "Jambi", "Jawa Barat", "Jawa Tengah", "Jawa Timur", "Kalimantan Barat", "Kalimantan Selatan", "Kalimantan Tengah", "Kalimantan Timur", "Kepulauan Bangka Belitung", "Kepulauan Riau", "Lampung", "Maluku", "Maluku Utara", "Nusa Tenggara Barat", "Nusa Tenggara Timur", "Papua", "Riau", "Sulawesi Barat", "Sulawesi Selatan", "Sulawesi Tengah", "Sulawesi Tenggara", "Sulawesi Utara", "Sumatera Barat", "Sumatera Selatan", "Sumatera Utara", "Yogyakarta"]
-    },
-    {
-      "country": "Iran",
-      "states": ["Ardabil", "Azarbayjan-e Gharbi", "Azarbayjan-e Sharqi", "Bushehr", "Chahar Mahall va Bakhtiari", "Esfahan", "Fars", "Gilan", "Golestan", "Hamadan", "Hormozgan", "Ilam", "Kerman", "Kermanshah", "Khorasan-e Janubi", "Khorasan-e Razavi", "Khorasan-e Shemali", "Khuzestan", "Kohgiluyeh va Buyer Ahmad", "Kordestan", "Lorestan", "Markazi", "Mazandaran", "Qazvin", "Qom", "Semnan", "Sistan va Baluchestan", "Tehran", "Yazd", "Zanjan"]
-    },
-    {
-      "country": "Iraq",
-      "states": ["Al Anbar", "Al Basrah", "Al Muthanna", "Al Qadisiyah", "An Najaf", "Arbil", "As Sulaymaniyah", "At Ta'mim", "Babil", "Baghdad", "Dahuk", "Dhi Qar", "Diyala", "Karbala'", "Maysan", "Ninawa", "Salah ad Din", "Wasit"]
-    },
-    {
-      "country": "Ireland",
-      "states": ["Carlow", "Cavan", "Clare", "Cork", "Donegal", "Dublin", "Galway", "Kerry", "Kildare", "Kilkenny", "Laois", "Leitrim", "Limerick", "Longford", "Louth", "Mayo", "Meath", "Monaghan", "Offaly", "Roscommon", "Sligo", "Tipperary", "Waterford", "Westmeath", "Wexford", "Wicklow"]
-    },
-    {
-      "country": "Israel",
-      "states": ["Central", "Haifa", "Jerusalem", "Northern", "Southern", "Tel Aviv"]
-    },
-    {
-      "country": "Italy",
-      "states": ["Abruzzo", "Basilicata", "Calabria", "Campania", "Emilia-Romagna", "Friuli-Venezia Giulia", "Lazio", "Liguria", "Lombardia", "Marche", "Molise", "Piemonte", "Puglia", "Sardegna", "Sicilia", "Toscana", "Trentino-Alto Adige", "Umbria", "Valle d'Aosta", "Veneto"]
-    },
-    {
-      "country": "Jamaica",
-      "states": ["Clarendon", "Hanover", "Kingston", "Manchester", "Portland", "Saint Andrew", "Saint Ann", "Saint Catherine", "Saint Elizabeth", "Saint James", "Saint Mary", "Saint Thomas", "Trelawny", "Westmoreland"]
-    },
-    {
-      "country": "Japan",
-      "states": ["Aichi", "Akita", "Aomori", "Chiba", "Ehime", "Fukui", "Fukuoka", "Fukushima", "Gifu", "Gumma", "Hiroshima", "Hokkaido", "Hyogo", "Ibaraki", "Ishikawa", "Iwate", "Kagawa", "Kagoshima", "Kanagawa", "Kochi", "Kumamoto", "Kyoto", "Mie", "Miyagi", "Miyazaki", "Nagano", "Nagasaki", "Nara", "Niigata", "Oita", "Okayama", "Okinawa", "Osaka", "Saga", "Saitama", "Shiga", "Shimane", "Shizuoka", "Tochigi", "Tokushima", "Tokyo", "Tottori", "Toyama", "Wakayama", "Yamagata", "Yamaguchi", "Yamanashi"]
-    },
-    {
-      "country": "Jordan",
-      "states": ["Ajlun", "Al 'Aqabah", "Al Balqa'", "Al Karak", "Al Mafraq", "'Amman", "At Tafilah", "Az Zarqa'", "Irbid", "Jarash", "Ma'an", "Madaba"]
-    },
-    {
-      "country": "Kazakhstan",
-      "states": ["Almaty Oblysy", "Almaty Qalasy", "Aqmola Oblysy", "Aqtobe Oblysy", "Astana Qalasy", "Atyrau Oblysy", "Batys Qazaqstan Oblysy", "Bayqongyr Qalasy", "Mangghystau Oblysy", "Ongtustik Qazaqstan Oblysy", "Pavlodar Oblysy", "Qaraghandy Oblysy", "Qostanay Oblysy", "Qyzylorda Oblysy", "Shyghys Qazaqstan Oblysy", "Soltustik Qazaqstan Oblysy", "Zhambyl Oblysy"]
-    },
-    {
-      "country": "Kenya",
-      "states": ["Central", "Coast", "Eastern", "Nairobi Area", "North Eastern", "Nyanza", "Rift Valley", "Western"]
-    },
-    {
-      "country": "Kiribati",
-      "states": []
-    },
-    {
-      "country": "Korea North",
-      "states": ["Chagang", "North Hamgyong", "South Hamgyong", "North Hwanghae", "South Hwanghae", "Kangwon", "North P'yongan", "South P'yongan", "Yanggang", "Kaesong", "Najin", "Namp'o", "Pyongyang"]
-    },
-    {
-      "country": "Korea South",
-      "states": ["Seoul", "Busan City", "Daegu City", "Incheon City", "Gwangju City", "Daejeon City", "Ulsan", "Gyeonggi Province", "Gangwon Province", "North Chungcheong Province", "South Chungcheong Province", "North Jeolla Province", "South Jeolla Province", "North Gyeongsang Province", "South Gyeongsang Province", "Jeju"]
-    },
-    {
-      "country": "Kuwait",
-      "states": ["Al Ahmadi", "Al Farwaniyah", "Al Asimah", "Al Jahra", "Hawalli", "Mubarak Al-Kabeer"]
-    },
-    {
-      "country": "Kyrgyzstan",
-      "states": ["Batken Oblasty", "Bishkek Shaary", "Chuy Oblasty", "Jalal-Abad Oblasty", "Naryn Oblasty", "Osh Oblasty", "Talas Oblasty", "Ysyk-Kol Oblasty"]
-    },
-    {
-      "country": "Laos",
-      "states": ["Attapu", "Bokeo", "Bolikhamxai", "Champasak", "Houaphan", "Khammouan", "Louangnamtha", "Louangphrabang", "Oudomxai", "Phongsali", "Salavan", "Savannakhet", "Viangchan", "Viangchan", "Xaignabouli", "Xaisomboun", "Xekong", "Xiangkhoang"]
-    },
-    {
-      "country": "Latvia",
-      "states": ["Aizkraukles Rajons", "Aluksnes Rajons", "Balvu Rajons", "Bauskas Rajons", "Cesu Rajons", "Daugavpils", "Daugavpils Rajons", "Dobeles Rajons", "Gulbenes Rajons", "Jekabpils Rajons", "Jelgava", "Jelgavas Rajons", "Jurmala", "Kraslavas Rajons", "Kuldigas Rajons", "Liepaja", "Liepajas Rajons", "Limbazu Rajons", "Ludzas Rajons", "Madonas Rajons", "Ogres Rajons", "Preilu Rajons", "Rezekne", "Rezeknes Rajons", "Riga", "Rigas Rajons", "Saldus Rajons", "Talsu Rajons", "Tukuma Rajons", "Valkas Rajons", "Valmieras Rajons", "Ventspils", "Ventspils Rajons"]
-    },
-    {
-      "country": "Lebanon",
-      "states": ["Beyrouth", "Beqaa", "Liban-Nord", "Liban-Sud", "Mont-Liban", "Nabatiye"]
-    },
-    {
-      "country": "Lesotho",
-      "states": ["Berea", "Butha-Buthe", "Leribe", "Mafeteng", "Maseru", "Mohale's Hoek", "Mokhotlong", "Qacha's Nek", "Quthing", "Thaba-Tseka"]
-    },
-    {
-      "country": "Liberia",
-      "states": ["Bomi", "Bong", "Gbarpolu", "Grand Bassa", "Grand Cape Mount", "Grand Gedeh", "Grand Kru", "Lofa", "Margibi", "Maryland", "Montserrado", "Nimba", "River Cess", "River Gee", "Sinoe"]
-    },
-    {
-      "country": "Libya",
-      "states": ["Ajdabiya", "Al 'Aziziyah", "Al Fatih", "Al Jabal al Akhdar", "Al Jufrah", "Al Khums", "Al Kufrah", "An Nuqat al Khams", "Ash Shati'", "Awbari", "Az Zawiyah", "Banghazi", "Darnah", "Ghadamis", "Gharyan", "Misratah", "Murzuq", "Sabha", "Sawfajjin", "Surt", "Tarabulus", "Tarhunah", "Tubruq", "Yafran", "Zlitan"]
-    },
-    {
-      "country": "Liechtenstein",
-      "states": ["Balzers", "Eschen", "Gamprin", "Mauren", "Planken", "Ruggell", "Schaan", "Schellenberg", "Triesen", "Triesenberg", "Vaduz"]
-    },
-    {
-      "country": "Lithuania",
-      "states": ["Alytaus", "Kauno", "Klaipedos", "Marijampoles", "Panevezio", "Siauliu", "Taurages", "Telsiu", "Utenos", "Vilniaus"]
-    },
-    {
-      "country": "Luxembourg",
-      "states": ["Diekirch", "Grevenmacher", "Luxembourg"]
-    },
-    {
-      "country": "Macedonia",
-      "states": ["Aerodrom", "Aracinovo", "Berovo", "Bitola", "Bogdanci", "Bogovinje", "Bosilovo", "Brvenica", "Butel", "Cair", "Caska", "Centar", "Centar Zupa", "Cesinovo", "Cucer-Sandevo", "Debar", "Debartsa", "Delcevo", "Demir Hisar", "Demir Kapija", "Dojran", "Dolneni", "Drugovo", "Gazi Baba", "Gevgelija", "Gjorce Petrov", "Gostivar", "Gradsko", "Ilinden", "Jegunovce", "Karbinci", "Karpos", "Kavadarci", "Kicevo", "Kisela Voda", "Kocani", "Konce", "Kratovo", "Kriva Palanka", "Krivogastani", "Krusevo", "Kumanovo", "Lipkovo", "Lozovo", "Makedonska Kamenica", "Makedonski Brod", "Mavrovo i Rastusa", "Mogila", "Negotino", "Novaci", "Novo Selo", "Ohrid", "Oslomej", "Pehcevo", "Petrovec", "Plasnica", "Prilep", "Probistip", "Radovis", "Rankovce", "Resen", "Rosoman", "Saraj", "Skopje", "Sopiste", "Staro Nagoricane", "Stip", "Struga", "Strumica", "Studenicani", "Suto Orizari", "Sveti Nikole", "Tearce", "Tetovo", "Valandovo", "Vasilevo", "Veles", "Vevcani", "Vinica", "Vranestica", "Vrapciste", "Zajas", "Zelenikovo", "Zelino", "Zrnovci"]
-    },
-    {
-      "country": "Madagascar",
-      "states": ["Antananarivo", "Antsiranana", "Fianarantsoa", "Mahajanga", "Toamasina", "Toliara"]
-    },
-    {
-      "country": "Malawi",
-      "states": ["Balaka", "Blantyre", "Chikwawa", "Chiradzulu", "Chitipa", "Dedza", "Dowa", "Karonga", "Kasungu", "Likoma", "Lilongwe", "Machinga", "Mangochi", "Mchinji", "Mulanje", "Mwanza", "Mzimba", "Ntcheu", "Nkhata Bay", "Nkhotakota", "Nsanje", "Ntchisi", "Phalombe", "Rumphi", "Salima", "Thyolo", "Zomba"]
-    },
-    {
-      "country": "Malaysia",
-      "states": ["Johor", "Kedah", "Kelantan", "Kuala Lumpur", "Labuan", "Malacca", "Negeri Sembilan", "Pahang", "Perak", "Perlis", "Penang", "Sabah", "Sarawak", "Selangor", "Terengganu"]
-    },
-    {
-      "country": "Maldives",
-      "states": ["Alifu", "Baa", "Dhaalu", "Faafu", "Gaafu Alifu", "Gaafu Dhaalu", "Gnaviyani", "Haa Alifu", "Haa Dhaalu", "Kaafu", "Laamu", "Lhaviyani", "Maale", "Meemu", "Noonu", "Raa", "Seenu", "Shaviyani", "Thaa", "Vaavu"]
-    },
-    {
-      "country": "Mali",
-      "states": ["Bamako (Capital)", "Gao", "Kayes", "Kidal", "Koulikoro", "Mopti", "Segou", "Sikasso", "Tombouctou"]
-    },
-    {
-      "country": "Malta",
-      "states": []
-    },
-    {
-      "country": "Marshall Islands",
-      "states": []
-    },
-    {
-      "country": "Mauritania",
-      "states": ["Adrar", "Assaba", "Brakna", "Dakhlet Nouadhibou", "Gorgol", "Guidimaka", "Hodh Ech Chargui", "Hodh El Gharbi", "Inchiri", "Nouakchott", "Tagant", "Tiris Zemmour", "Trarza"]
-    },
-    {
-      "country": "Mauritius",
-      "states": ["Agalega Islands", "Black River", "Cargados Carajos Shoals", "Flacq", "Grand Port", "Moka", "Pamplemousses", "Plaines Wilhems", "Port Louis", "Riviere du Rempart", "Rodrigues", "Savanne"]
-    },
-    {
-      "country": "Mexico",
-      "states": ["Aguascalientes", "Baja California", "Baja California Sur", "Campeche", "Chiapas", "Chihuahua", "Coahuila de Zaragoza", "Colima", "Distrito Federal", "Durango", "Guanajuato", "Guerrero", "Hidalgo", "Jalisco", "Mexico", "Michoacan de Ocampo", "Morelos", "Nayarit", "Nuevo Leon", "Oaxaca", "Puebla", "Queretaro de Arteaga", "Quintana Roo", "San Luis Potosi", "Sinaloa", "Sonora", "Tabasco", "Tamaulipas", "Tlaxcala", "Veracruz-Llave", "Yucatan", "Zacatecas"]
-    },
-    {
-      "country": "Micronesia",
-      "states": []
-    },
-    {
-      "country": "Moldova",
-      "states": ["Anenii Noi", "Basarabeasca", "Briceni", "Cahul", "Cantemir", "Calarasi", "Causeni", "Cimislia", "Criuleni", "Donduseni", "Drochia", "Dubasari", "Edinet", "Falesti", "Floresti", "Glodeni", "Hincesti", "Ialoveni", "Leova", "Nisporeni", "Ocnita", "Orhei", "Rezina", "Riscani", "Singerei", "Soldanesti", "Soroca", "Stefan-Voda", "Straseni", "Taraclia", "Telenesti", "Ungheni", "Balti", "Bender", "Chisinau", "Gagauzia", "Stinga Nistrului"]
-    },
-    {
-      "country": "Mongolia",
-      "states": ["Arhangay", "Bayanhongor", "Bayan-Olgiy", "Bulgan", "Darhan Uul", "Dornod", "Dornogovi", "Dundgovi", "Dzavhan", "Govi-Altay", "Govi-Sumber", "Hentiy", "Hovd", "Hovsgol", "Omnogovi", "Orhon", "Ovorhangay", "Selenge", "Suhbaatar", "Tov", "Ulaanbaatar", "Uvs"]
-    },
-    {
-      "country": "Morocco",
-      "states": ["Agadir", "Al Hoceima", "Azilal", "Beni Mellal", "Ben Slimane", "Boulemane", "Casablanca", "Chaouen", "El Jadida", "El Kelaa des Sraghna", "Er Rachidia", "Essaouira", "Fes", "Figuig", "Guelmim", "Ifrane", "Kenitra", "Khemisset", "Khenifra", "Khouribga", "Laayoune", "Larache", "Marrakech", "Meknes", "Nador", "Ouarzazate", "Oujda", "Rabat-Sale", "Safi", "Settat", "Sidi Kacem", "Tangier", "Tan-Tan", "Taounate", "Taroudannt", "Tata", "Taza", "Tetouan", "Tiznit"]
-    },
-    {
-      "country": "Monaco",
-      "states": []
-    },
-    {
-      "country": "Mozambique",
-      "states": ["Cabo Delgado", "Gaza", "Inhambane", "Manica", "Maputo", "Cidade de Maputo", "Nampula", "Niassa", "Sofala", "Tete", "Zambezia"]
-    },
-    {
-      "country": "Namibia",
-      "states": ["Caprivi", "Erongo", "Hardap", "Karas", "Khomas", "Kunene", "Ohangwena", "Okavango", "Omaheke", "Omusati", "Oshana", "Oshikoto", "Otjozondjupa"]
-    },
-    {
-      "country": "Nauru",
-      "states": []
-    },
-    {
-      "country": "Nepal",
-      "states": ["Bagmati", "Bheri", "Dhawalagiri", "Gandaki", "Janakpur", "Karnali", "Kosi", "Lumbini", "Mahakali", "Mechi", "Narayani", "Rapti", "Sagarmatha", "Seti"]
-    },
-    {
-      "country": "Netherlands",
-      "states": ["Drenthe", "Flevoland", "Friesland", "Gelderland", "Groningen", "Limburg", "Noord-Brabant", "Noord-Holland", "Overijssel", "Utrecht", "Zeeland", "Zuid-Holland"]
-    },
-    {
-      "country": "New Zealand",
-      "states": ["Auckland", "Bay of Plenty", "Canterbury", "Chatham Islands", "Gisborne", "Hawke's Bay", "Manawatu-Wanganui", "Marlborough", "Nelson", "Northland", "Otago", "Southland", "Taranaki", "Tasman", "Waikato", "Wellington", "West Coast"]
-    },
-    {
-      "country": "Nicaragua",
-      "states": ["Atlantico Norte", "Atlantico Sur", "Boaco", "Carazo", "Chinandega", "Chontales", "Esteli", "Granada", "Jinotega", "Leon", "Madriz", "Managua", "Masaya", "Matagalpa", "Nueva Segovia", "Rio San Juan", "Rivas"]
-    },
-    {
-      "country": "Niger",
-      "states": ["Agadez", "Diffa", "Dosso", "Maradi", "Niamey", "Tahoua", "Tillaberi", "Zinder"]
-    },
-    {
-      "country": "Nigeria",
-      "states": ["Abia", "Abuja Federal Capital", "Adamawa", "Akwa Ibom", "Anambra", "Bauchi", "Bayelsa", "Benue", "Borno", "Cross River", "Delta", "Ebonyi", "Edo", "Ekiti", "Enugu", "Gombe", "Imo", "Jigawa", "Kaduna", "Kano", "Katsina", "Kebbi", "Kogi", "Kwara", "Lagos", "Nassarawa", "Niger", "Ogun", "Ondo", "Osun", "Oyo", "Plateau", "Rivers", "Sokoto", "Taraba", "Yobe", "Zamfara"]
-    },
-    {
-      "country": "Norway",
-      "states": ["Akershus", "Aust-Agder", "Buskerud", "Finnmark", "Hedmark", "Hordaland", "More og Romsdal", "Nordland", "Nord-Trondelag", "Oppland", "Oslo", "Ostfold", "Rogaland", "Sogn og Fjordane", "Sor-Trondelag", "Telemark", "Troms", "Vest-Agder", "Vestfold"]
-    },
-    {
-      "country": "Oman",
-      "states": ["Ad Dakhiliyah", "Al Batinah", "Al Wusta", "Ash Sharqiyah", "Az Zahirah", "Masqat", "Musandam", "Dhofar"]
-    },
-    {
-      "country": "Pakistan",
-      "states": ["Balochistan", "North-West Frontier Province", "Punjab", "Sindh", "Islamabad Capital Territory", "Federally Administered Tribal Areas"]
-    },
-    {
-      "country": "Panama",
-      "states": ["Bocas del Toro", "Chiriqui", "Cocle", "Colon", "Darien", "Herrera", "Los Santos", "Panama", "San Blas", "Veraguas"]
-    },
-    {
-      "country": "Papua New Guinea",
-      "states": ["Bougainville", "Central", "Chimbu", "Eastern Highlands", "East New Britain", "East Sepik", "Enga", "Gulf", "Madang", "Manus", "Milne Bay", "Morobe", "National Capital", "New Ireland", "Northern", "Sandaun", "Southern Highlands", "Western", "Western Highlands", "West New Britain"]
-    },
-    {
-      "country": "Paraguay",
-      "states": ["Alto Paraguay", "Alto Parana", "Amambay", "Asuncion", "Boqueron", "Caaguazu", "Caazapa", "Canindeyu", "Central", "Concepcion", "Cordillera", "Guaira", "Itapua", "Misiones", "Neembucu", "Paraguari", "Presidente Hayes", "San Pedro"]
-    },
-    {
-      "country": "Peru",
-      "states": ["Amazonas", "Ancash", "Apurimac", "Arequipa", "Ayacucho", "Cajamarca", "Callao", "Cusco", "Huancavelica", "Huanuco", "Ica", "Junin", "La Libertad", "Lambayeque", "Lima", "Loreto", "Madre de Dios", "Moquegua", "Pasco", "Piura", "Puno", "San Martin", "Tacna", "Tumbes", "Ucayali"]
-    },
-    {
-      "country": "Philippines",
-      "states": ["Abra", "Agusan del Norte", "Agusan del Sur", "Aklan", "Albay", "Antique", "Apayao", "Aurora", "Basilan", "Bataan", "Batanes", "Batangas", "Biliran", "Benguet", "Bohol", "Bukidnon", "Bulacan", "Cagayan", "Camarines Norte", "Camarines Sur", "Camiguin", "Capiz", "Catanduanes", "Cavite", "Cebu", "Compostela", "Davao del Norte", "Davao del Sur", "Davao Oriental", "Eastern Samar", "Guimaras", "Ifugao", "Ilocos Norte", "Ilocos Sur", "Iloilo", "Isabela", "Kalinga", "Laguna", "Lanao del Norte", "Lanao del Sur", "La Union", "Leyte", "Maguindanao", "Marinduque", "Masbate", "Mindoro Occidental", "Mindoro Oriental", "Misamis Occidental", "Misamis Oriental", "Mountain Province", "Negros Occidental", "Negros Oriental", "North Cotabato", "Northern Samar", "Nueva Ecija", "Nueva Vizcaya", "Palawan", "Pampanga", "Pangasinan", "Quezon", "Quirino", "Rizal", "Romblon", "Samar", "Sarangani", "Siquijor", "Sorsogon", "South Cotabato", "Southern Leyte", "Sultan Kudarat", "Sulu", "Surigao del Norte", "Surigao del Sur", "Tarlac", "Tawi-Tawi", "Zambales", "Zamboanga del Norte", "Zamboanga del Sur", "Zamboanga Sibugay"]
-    },
-    {
-      "country": "Poland",
-      "states": ["Greater Poland (Wielkopolskie)", "Kuyavian-Pomeranian (Kujawsko-Pomorskie)", "Lesser Poland (Malopolskie)", "Lodz (Lodzkie)", "Lower Silesian (Dolnoslaskie)", "Lublin (Lubelskie)", "Lubusz (Lubuskie)", "Masovian (Mazowieckie)", "Opole (Opolskie)", "Podlasie (Podlaskie)", "Pomeranian (Pomorskie)", "Silesian (Slaskie)", "Subcarpathian (Podkarpackie)", "Swietokrzyskie (Swietokrzyskie)", "Warmian-Masurian (Warminsko-Mazurskie)", "West Pomeranian (Zachodniopomorskie)"]
-    },
-    {
-      "country": "Portugal",
-      "states": ["Aveiro", "Acores", "Beja", "Braga", "Braganca", "Castelo Branco", "Coimbra", "Evora", "Faro", "Guarda", "Leiria", "Lisboa", "Madeira", "Portalegre", "Porto", "Santarem", "Setubal", "Viana do Castelo", "Vila Real", "Viseu"]
-    },
-    {
-      "country": "Qatar",
-      "states": ["Ad Dawhah", "Al Ghuwayriyah", "Al Jumayliyah", "Al Khawr", "Al Wakrah", "Ar Rayyan", "Jarayan al Batinah", "Madinat ash Shamal", "Umm Sa'id", "Umm Salal"]
-    },
-    {
-      "country": "Romania",
-      "states": ["Alba", "Arad", "Arges", "Bacau", "Bihor", "Bistrita-Nasaud", "Botosani", "Braila", "Brasov", "Bucuresti", "Buzau", "Calarasi", "Caras-Severin", "Cluj", "Constanta", "Covasna", "Dimbovita", "Dolj", "Galati", "Gorj", "Giurgiu", "Harghita", "Hunedoara", "Ialomita", "Iasi", "Ilfov", "Maramures", "Mehedinti", "Mures", "Neamt", "Olt", "Prahova", "Salaj", "Satu Mare", "Sibiu", "Suceava", "Teleorman", "Timis", "Tulcea", "Vaslui", "Vilcea", "Vrancea"]
-    },
-    {
-      "country": "Russia",
-      "states": ["Amur", "Arkhangel'sk", "Astrakhan'", "Belgorod", "Bryansk", "Chelyabinsk", "Chita", "Irkutsk", "Ivanovo", "Kaliningrad", "Kaluga", "Kamchatka", "Kemerovo", "Kirov", "Kostroma", "Kurgan", "Kursk", "Leningrad", "Lipetsk", "Magadan", "Moscow", "Murmansk", "Nizhniy Novgorod", "Novgorod", "Novosibirsk", "Omsk", "Orenburg", "Orel", "Penza", "Perm'", "Pskov", "Rostov", "Ryazan'", "Sakhalin", "Samara", "Saratov", "Smolensk", "Sverdlovsk", "Tambov", "Tomsk", "Tula", "Tver'", "Tyumen'", "Ul'yanovsk", "Vladimir", "Volgograd", "Vologda", "Voronezh", "Yaroslavl'", "Adygeya", "Altay", "Bashkortostan", "Buryatiya", "Chechnya", "Chuvashiya", "Dagestan", "Ingushetiya", "Kabardino-Balkariya", "Kalmykiya", "Karachayevo-Cherkesiya", "Kareliya", "Khakasiya", "Komi", "Mariy-El", "Mordoviya", "Sakha", "North Ossetia", "Tatarstan", "Tyva", "Udmurtiya", "Aga Buryat", "Chukotka", "Evenk", "Khanty-Mansi", "Komi-Permyak", "Koryak", "Nenets", "Taymyr", "Ust'-Orda Buryat", "Yamalo-Nenets", "Altay", "Khabarovsk", "Krasnodar", "Krasnoyarsk", "Primorskiy", "Stavropol'", "Moscow", "St. Petersburg", "Yevrey"]
-    },
-    {
-      "country": "Rwanda",
-      "states": ["Butare", "Byumba", "Cyangugu", "Gikongoro", "Gisenyi", "Gitarama", "Kibungo", "Kibuye", "Kigali Rurale", "Kigali-ville", "Umutara", "Ruhengeri"]
-    },
-    {
-      "country": "Samoa",
-      "states": ["A'ana", "Aiga-i-le-Tai", "Atua", "Fa'asaleleaga", "Gaga'emauga", "Gagaifomauga", "Palauli", "Satupa'itea", "Tuamasaga", "Va'a-o-Fonoti", "Vaisigano"]
-    },
-    {
-      "country": "San Marino",
-      "states": ["Acquaviva", "Borgo Maggiore", "Chiesanuova", "Domagnano", "Faetano", "Fiorentino", "Montegiardino", "San Marino Citta", "Serravalle"]
-    },
-    {
-      "country": "Sao Tome",
-      "states": []
-    },
-    {
-      "country": "Saudi Arabia",
-      "states": ["Al Bahah", "Al Hudud ash Shamaliyah", "Al Jawf", "Al Madinah", "Al Qasim", "Ar Riyad", "Ash Sharqiyah", "'Asir", "Ha'il", "Jizan", "Makkah", "Najran", "Tabuk"]
-    },
-    {
-      "country": "Senegal",
-      "states": ["Dakar", "Diourbel", "Fatick", "Kaolack", "Kolda", "Louga", "Matam", "Saint-Louis", "Tambacounda", "Thies", "Ziguinchor"]
-    },
-    {
-      "country": "Serbia and Montenegro",
-      "states": ["Kosovo", "Montenegro", "Serbia", "Vojvodina"]
-    },
-    {
-      "country": "Seychelles",
-      "states": ["Anse aux Pins", "Anse Boileau", "Anse Etoile", "Anse Louis", "Anse Royale", "Baie Lazare", "Baie Sainte Anne", "Beau Vallon", "Bel Air", "Bel Ombre", "Cascade", "Glacis", "Grand' Anse", "Grand' Anse", "La Digue", "La Riviere Anglaise", "Mont Buxton", "Mont Fleuri", "Plaisance", "Pointe La Rue", "Port Glaud", "Saint Louis", "Takamaka"]
-    },
-    {
-      "country": "Sierra Leone",
-      "states": []
-    },
-    {
-      "country": "Singapore",
-      "states": []
-    },
-    {
-      "country": "Slovakia",
-      "states": ["Banskobystricky", "Bratislavsky", "Kosicky", "Nitriansky", "Presovsky", "Trenciansky", "Trnavsky", "Zilinsky"]
-    },
-    {
-      "country": "Slovenia",
-      "states": ["Ajdovscina", "Beltinci", "Benedikt", "Bistrica ob Sotli", "Bled", "Bloke", "Bohinj", "Borovnica", "Bovec", "Braslovce", "Brda", "Brezice", "Brezovica", "Cankova", "Celje", "Cerklje na Gorenjskem", "Cerknica", "Cerkno", "Cerkvenjak", "Crensovci", "Crna na Koroskem", "Crnomelj", "Destrnik", "Divaca", "Dobje", "Dobrepolje", "Dobrna", "Dobrova-Horjul-Polhov Gradec", "Dobrovnik-Dobronak", "Dolenjske Toplice", "Dol pri Ljubljani", "Domzale", "Dornava", "Dravograd", "Duplek", "Gorenja Vas-Poljane", "Gorisnica", "Gornja Radgona", "Gornji Grad", "Gornji Petrovci", "Grad", "Grosuplje", "Hajdina", "Hoce-Slivnica", "Hodos-Hodos", "Horjul", "Hrastnik", "Hrpelje-Kozina", "Idrija", "Ig", "Ilirska Bistrica", "Ivancna Gorica", "Izola-Isola", "Jesenice", "Jezersko", "Jursinci", "Kamnik", "Kanal", "Kidricevo", "Kobarid", "Kobilje", "Kocevje", "Komen", "Komenda", "Koper-Capodistria", "Kostel", "Kozje", "Kranj", "Kranjska Gora", "Krizevci", "Krsko", "Kungota", "Kuzma", "Lasko", "Lenart", "Lendava-Lendva", "Litija", "Ljubljana", "Ljubno", "Ljutomer", "Logatec", "Loska Dolina", "Loski Potok", "Lovrenc na Pohorju", "Luce", "Lukovica", "Majsperk", "Maribor", "Markovci", "Medvode", "Menges", "Metlika", "Mezica", "Miklavz na Dravskem Polju", "Miren-Kostanjevica", "Mirna Pec", "Mislinja", "Moravce", "Moravske Toplice", "Mozirje", "Murska Sobota", "Muta", "Naklo", "Nazarje", "Nova Gorica", "Novo Mesto", "Odranci", "Oplotnica", "Ormoz", "Osilnica", "Pesnica", "Piran-Pirano", "Pivka", "Podcetrtek", "Podlehnik", "Podvelka", "Polzela", "Postojna", "Prebold", "Preddvor", "Prevalje", "Ptuj", "Puconci", "Race-Fram", "Radece", "Radenci", "Radlje ob Dravi", "Radovljica", "Ravne na Koroskem", "Razkrizje", "Ribnica", "Ribnica na Pohorju", "Rogasovci", "Rogaska Slatina", "Rogatec", "Ruse", "Salovci", "Selnica ob Dravi", "Semic", "Sempeter-Vrtojba", "Sencur", "Sentilj", "Sentjernej", "Sentjur pri Celju", "Sevnica", "Sezana", "Skocjan", "Skofja Loka", "Skofljica", "Slovenj Gradec", "Slovenska Bistrica", "Slovenske Konjice", "Smarje pri Jelsah", "Smartno ob Paki", "Smartno pri Litiji", "Sodrazica", "Solcava", "Sostanj", "Starse", "Store", "Sveta Ana", "Sveti Andraz v Slovenskih Goricah", "Sveti Jurij", "Tabor", "Tisina", "Tolmin", "Trbovlje", "Trebnje", "Trnovska Vas", "Trzic", "Trzin", "Turnisce", "Velenje", "Velika Polana", "Velike Lasce", "Verzej", "Videm", "Vipava", "Vitanje", "Vodice", "Vojnik", "Vransko", "Vrhnika", "Vuzenica", "Zagorje ob Savi", "Zalec", "Zavrc", "Zelezniki", "Zetale", "Ziri", "Zirovnica", "Zuzemberk", "Zrece"]
-    },
-    {
-      "country": "Solomon Islands",
-      "states": ["Central", "Choiseul", "Guadalcanal", "Honiara", "Isabel", "Makira", "Malaita", "Rennell and Bellona", "Temotu", "Western"]
-    },
-    {
-      "country": "Somalia",
-      "states": ["Awdal", "Bakool", "Banaadir", "Bari", "Bay", "Galguduud", "Gedo", "Hiiraan", "Jubbada Dhexe", "Jubbada Hoose", "Mudug", "Nugaal", "Sanaag", "Shabeellaha Dhexe", "Shabeellaha Hoose", "Sool", "Togdheer", "Woqooyi Galbeed"]
-    },
-    {
-      "country": "South Africa",
-      "states": ["Eastern Cape", "Free State", "Gauteng", "KwaZulu-Natal", "Limpopo", "Mpumalanga", "North-West", "Northern Cape", "Western Cape"]
-    },
-    {
-      "country": "Spain",
-      "states": ["Andalucia", "Aragon", "Asturias", "Baleares", "Ceuta", "Canarias", "Cantabria", "Castilla-La Mancha", "Castilla y Leon", "Cataluna", "Comunidad Valenciana", "Extremadura", "Galicia", "La Rioja", "Madrid", "Melilla", "Murcia", "Navarra", "Pais Vasco"]
-    },
-    {
-      "country": "Sri Lanka",
-      "states": ["Central", "North Central", "North Eastern", "North Western", "Sabaragamuwa", "Southern", "Uva", "Western"]
-    },
-    {
-      "country": "Sudan",
-      "states": ["A'ali an Nil", "Al Bahr al Ahmar", "Al Buhayrat", "Al Jazirah", "Al Khartum", "Al Qadarif", "Al Wahdah", "An Nil al Abyad", "An Nil al Azraq", "Ash Shamaliyah", "Bahr al Jabal", "Gharb al Istiwa'iyah", "Gharb Bahr al Ghazal", "Gharb Darfur", "Gharb Kurdufan", "Janub Darfur", "Janub Kurdufan", "Junqali", "Kassala", "Nahr an Nil", "Shamal Bahr al Ghazal", "Shamal Darfur", "Shamal Kurdufan", "Sharq al Istiwa'iyah", "Sinnar", "Warab"]
-    },
-    {
-      "country": "Suriname",
-      "states": ["Brokopondo", "Commewijne", "Coronie", "Marowijne", "Nickerie", "Para", "Paramaribo", "Saramacca", "Sipaliwini", "Wanica"]
-    },
-    {
-      "country": "Swaziland",
-      "states": ["Hhohho", "Lubombo", "Manzini", "Shiselweni"]
-    },
-    {
-      "country": "Sweden",
-      "states": ["Blekinge", "Dalarnas", "Gavleborgs", "Gotlands", "Hallands", "Jamtlands", "Jonkopings", "Kalmar", "Kronobergs", "Norrbottens", "Orebro", "Ostergotlands", "Skane", "Sodermanlands", "Stockholms", "Uppsala", "Varmlands", "Vasterbottens", "Vasternorrlands", "Vastmanlands", "Vastra Gotalands"]
-    },
-    {
-      "country": "Switzerland",
-      "states": ["Aargau", "Appenzell Ausser-Rhoden", "Appenzell Inner-Rhoden", "Basel-Landschaft", "Basel-Stadt", "Bern", "Fribourg", "Geneve", "Glarus", "Graubunden", "Jura", "Luzern", "Neuchatel", "Nidwalden", "Obwalden", "Sankt Gallen", "Schaffhausen", "Schwyz", "Solothurn", "Thurgau", "Ticino", "Uri", "Valais", "Vaud", "Zug", "Zurich"]
-    },
-    {
-      "country": "Syria",
-      "states": ["Al Hasakah", "Al Ladhiqiyah", "Al Qunaytirah", "Ar Raqqah", "As Suwayda'", "Dar'a", "Dayr az Zawr", "Dimashq", "Halab", "Hamah", "Hims", "Idlib", "Rif Dimashq", "Tartus"]
-    },
-    {
-      "country": "Taiwan",
-      "states": ["Chang-hua", "Chia-i", "Hsin-chu", "Hua-lien", "I-lan", "Kao-hsiung", "Kin-men", "Lien-chiang", "Miao-li", "Nan-t'ou", "P'eng-hu", "P'ing-tung", "T'ai-chung", "T'ai-nan", "T'ai-pei", "T'ai-tung", "T'ao-yuan", "Yun-lin", "Chia-i", "Chi-lung", "Hsin-chu", "T'ai-chung", "T'ai-nan", "Kao-hsiung city", "T'ai-pei city"]
-    },
-    {
-      "country": "Tajikistan",
-      "states": []
-    },
-    {
-      "country": "Tanzania",
-      "states": ["Arusha", "Dar es Salaam", "Dodoma", "Iringa", "Kagera", "Kigoma", "Kilimanjaro", "Lindi", "Manyara", "Mara", "Mbeya", "Morogoro", "Mtwara", "Mwanza", "Pemba North", "Pemba South", "Pwani", "Rukwa", "Ruvuma", "Shinyanga", "Singida", "Tabora", "Tanga", "Zanzibar Central/South", "Zanzibar North", "Zanzibar Urban/West"]
-    },
-    {
-      "country": "Thailand",
-      "states": ["Amnat Charoen", "Ang Thong", "Buriram", "Chachoengsao", "Chai Nat", "Chaiyaphum", "Chanthaburi", "Chiang Mai", "Chiang Rai", "Chon Buri", "Chumphon", "Kalasin", "Kamphaeng Phet", "Kanchanaburi", "Khon Kaen", "Krabi", "Krung Thep Mahanakhon", "Lampang", "Lamphun", "Loei", "Lop Buri", "Mae Hong Son", "Maha Sarakham", "Mukdahan", "Nakhon Nayok", "Nakhon Pathom", "Nakhon Phanom", "Nakhon Ratchasima", "Nakhon Sawan", "Nakhon Si Thammarat", "Nan", "Narathiwat", "Nong Bua Lamphu", "Nong Khai", "Nonthaburi", "Pathum Thani", "Pattani", "Phangnga", "Phatthalung", "Phayao", "Phetchabun", "Phetchaburi", "Phichit", "Phitsanulok", "Phra Nakhon Si Ayutthaya", "Phrae", "Phuket", "Prachin Buri", "Prachuap Khiri Khan", "Ranong", "Ratchaburi", "Rayong", "Roi Et", "Sa Kaeo", "Sakon Nakhon", "Samut Prakan", "Samut Sakhon", "Samut Songkhram", "Sara Buri", "Satun", "Sing Buri", "Sisaket", "Songkhla", "Sukhothai", "Suphan Buri", "Surat Thani", "Surin", "Tak", "Trang", "Trat", "Ubon Ratchathani", "Udon Thani", "Uthai Thani", "Uttaradit", "Yala", "Yasothon"]
-    },
-    {
-      "country": "Togo",
-      "states": ["Kara", "Plateaux", "Savanes", "Centrale", "Maritime"]
-    },
-    {
-      "country": "Tonga",
-      "states": []
-    },
-    {
-      "country": "Trinidad and Tobago",
-      "states": ["Couva", "Diego Martin", "Mayaro", "Penal", "Princes Town", "Sangre Grande", "San Juan", "Siparia", "Tunapuna", "Port-of-Spain", "San Fernando", "Arima", "Point Fortin", "Chaguanas", "Tobago"]
-    },
-    {
-      "country": "Tunisia",
-      "states": ["Ariana (Aryanah)", "Beja (Bajah)", "Ben Arous (Bin 'Arus)", "Bizerte (Banzart)", "Gabes (Qabis)", "Gafsa (Qafsah)", "Jendouba (Jundubah)", "Kairouan (Al Qayrawan)", "Kasserine (Al Qasrayn)", "Kebili (Qibili)", "Kef (Al Kaf)", "Mahdia (Al Mahdiyah)", "Manouba (Manubah)", "Medenine (Madanin)", "Monastir (Al Munastir)", "Nabeul (Nabul)", "Sfax (Safaqis)", "Sidi Bou Zid (Sidi Bu Zayd)", "Siliana (Silyanah)", "Sousse (Susah)", "Tataouine (Tatawin)", "Tozeur (Tawzar)", "Tunis", "Zaghouan (Zaghwan)"]
-    },
-    {
-      "country": "Turkey",
-      "states": ["Adana", "Adiyaman", "Afyonkarahisar", "Agri", "Aksaray", "Amasya", "Ankara", "Antalya", "Ardahan", "Artvin", "Aydin", "Balikesir", "Bartin", "Batman", "Bayburt", "Bilecik", "Bingol", "Bitlis", "Bolu", "Burdur", "Bursa", "Canakkale", "Cankiri", "Corum", "Denizli", "Diyarbakir", "Duzce", "Edirne", "Elazig", "Erzincan", "Erzurum", "Eskisehir", "Gaziantep", "Giresun", "Gumushane", "Hakkari", "Hatay", "Igdir", "Isparta", "Istanbul", "Izmir", "Kahramanmaras", "Karabuk", "Karaman", "Kars", "Kastamonu", "Kayseri", "Kilis", "Kirikkale", "Kirklareli", "Kirsehir", "Kocaeli", "Konya", "Kutahya", "Malatya", "Manisa", "Mardin", "Mersin", "Mugla", "Mus", "Nevsehir", "Nigde", "Ordu", "Osmaniye", "Rize", "Sakarya", "Samsun", "Sanliurfa", "Siirt", "Sinop", "Sirnak", "Sivas", "Tekirdag", "Tokat", "Trabzon", "Tunceli", "Usak", "Van", "Yalova", "Yozgat", "Zonguldak"]
-    },
-    {
-      "country": "Turkmenistan",
-      "states": ["Ahal Welayaty (Ashgabat)", "Balkan Welayaty (Balkanabat)", "Dashoguz Welayaty", "Lebap Welayaty (Turkmenabat)", "Mary Welayaty"]
-    },
-    {
-      "country": "Uganda",
-      "states": ["Adjumani", "Apac", "Arua", "Bugiri", "Bundibugyo", "Bushenyi", "Busia", "Gulu", "Hoima", "Iganga", "Jinja", "Kabale", "Kabarole", "Kaberamaido", "Kalangala", "Kampala", "Kamuli", "Kamwenge", "Kanungu", "Kapchorwa", "Kasese", "Katakwi", "Kayunga", "Kibale", "Kiboga", "Kisoro", "Kitgum", "Kotido", "Kumi", "Kyenjojo", "Lira", "Luwero", "Masaka", "Masindi", "Mayuge", "Mbale", "Mbarara", "Moroto", "Moyo", "Mpigi", "Mubende", "Mukono", "Nakapiripirit", "Nakasongola", "Nebbi", "Ntungamo", "Pader", "Pallisa", "Rakai", "Rukungiri", "Sembabule", "Sironko", "Soroti", "Tororo", "Wakiso", "Yumbe"]
-    },
-    {
-      "country": "Ukraine",
-      "states": ["Cherkasy", "Chernihiv", "Chernivtsi", "Crimea", "Dnipropetrovs'k", "Donets'k", "Ivano-Frankivs'k", "Kharkiv", "Kherson", "Khmel'nyts'kyy", "Kirovohrad", "Kiev", "Kyyiv", "Luhans'k", "L'viv", "Mykolayiv", "Odesa", "Poltava", "Rivne", "Sevastopol'", "Sumy", "Ternopil'", "Vinnytsya", "Volyn'", "Zakarpattya", "Zaporizhzhya", "Zhytomyr"]
-    },
-    {
-      "country": "United Arab Emirates",
-      "states": ["Abu Dhabi", "'Ajman", "Al Fujayrah", "Sharjah", "Dubai", "Ra's al Khaymah", "Umm al Qaywayn"]
-    },
-    {
+  {
+    "country": "United States",
+    "states": [
+      "Alabama",
+      "Alaska",
+      "Arizona",
+      "Arkansas",
+      "California",
+      "Colorado",
+      "Connecticut",
+      "Delaware",
+      "District of Columbia",
+      "Florida",
+      "Georgia",
+      "Hawaii",
+      "Idaho",
+      "Illinois",
+      "Indiana",
+      "Iowa",
+      "Kansas",
+      "Kentucky",
+      "Louisiana",
+      "Maine",
+      "Maryland",
+      "Massachusetts",
+      "Michigan",
+      "Minnesota",
+      "Mississippi",
+      "Missouri",
+      "Montana",
+      "Nebraska",
+      "Nevada",
+      "New Hampshire",
+      "New Jersey",
+      "New Mexico",
+      "New York",
+      "North Carolina",
+      "North Dakota",
+      "Ohio",
+      "Oklahoma",
+      "Oregon",
+      "Pennsylvania",
+      "Rhode Island",
+      "South Carolina",
+      "South Dakota",
+      "Tennessee",
+      "Texas",
+      "Utah",
+      "Vermont",
+      "Virginia",
+      "Washington",
+      "West Virginia",
+      "Wisconsin",
+      "Wyoming"
+    ],
+    "country_code": "US"
+  },
+  {
     "country": "United Kingdom",
-    "states": [ "Aberconwy and Colwyn", "Aberdeen City", "Aberdeenshire", "Anglesey", "Angus", "Antrim", "Argyll and Bute", "Armagh", "Avon", "Ayrshire", "Bath and NE Somerset", "Bedfordshire", "Belfast", "Berkshire", "Berwickshire", "BFPO", "Blaenau Gwent", "Buckinghamshire", "Caernarfonshire", "Caerphilly", "Caithness", "Cambridgeshire", "Cardiff", "Cardiganshire", "Carmarthenshire", "Ceredigion", "Channel Islands", "Cheshire", "City of Bristol", "Clackmannanshire", "Clwyd", "Conwy", "Cornwall/Scilly", "Cumbria", "Denbighshire", "Derbyshire", "Derry/Londonderry", "Devon", "Dorset", "Down", "Dumfries and Galloway", "Dunbartonshire", "Dundee", "Durham", "Dyfed", "East Ayrshire", "East Dunbartonshire", "East Lothian", "East Renfrewshire", "East Riding Yorkshire", "East Sussex", "Edinburgh", "England", "Essex", "Falkirk", "Fermanagh", "Fife", "Flintshire", "Glasgow", "Gloucestershire", "Greater London", "Greater Manchester", "Gwent", "Gwynedd", "Hampshire", "Hartlepool", "Hereford and Worcester", "Hertfordshire", "Highlands", "Inverclyde", "Inverness-Shire", "Isle of Man", "Isle of Wight", "Kent", "Kincardinshire", "Kingston Upon Hull", "Kinross-Shire", "Kirklees", "Lanarkshire", "Lancashire", "Leicestershire", "Lincolnshire", "Londonderry", "Merseyside", "Merthyr Tydfil", "Mid Glamorgan", "Mid Lothian", "Middlesex", "Monmouthshire", "Moray", "Neath & Port Talbot", "Newport", "Norfolk", "North Ayrshire", "North East Lincolnshire", "North Lanarkshire", "North Lincolnshire", "North Somerset", "North Yorkshire", "Northamptonshire", "Northern Ireland", "Northumberland", "Nottinghamshire", "Orkney and Shetland Isles", "Oxfordshire", "Pembrokeshire", "Perth and Kinross", "Powys", "Redcar and Cleveland", "Renfrewshire", "Rhonda Cynon Taff", "Rutland", "Scottish Borders", "Shetland", "Shropshire", "Somerset", "South Ayrshire", "South Glamorgan", "South Gloucesteshire", "South Lanarkshire", "South Yorkshire", "Staffordshire", "Stirling", "Stockton On Tees", "Suffolk", "Surrey", "Swansea", "Torfaen", "Tyne and Wear", "Tyrone", "Vale Of Glamorgan", "Wales", "Warwickshire", "West Berkshire", "West Dunbartonshire", "West Glamorgan", "West Lothian", "West Midlands", "West Sussex", "West Yorkshire", "Western Isles", "Wiltshire", "Wirral", "Worcestershire", "Wrexham", "York" ]
-    },
-    {
-      "country": "United States",
-      "states": ["Alabama", "Alaska", "Arizona", "Arkansas", "California", "Colorado", "Connecticut", "Delaware", "District of Columbia", "Florida", "Georgia", "Hawaii", "Idaho", "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana", "Maine", "Maryland", "Massachusetts", "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada", "New Hampshire", "New Jersey", "New Mexico", "New York", "North Carolina", "North Dakota", "Ohio", "Oklahoma", "Oregon", "Pennsylvania", "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas", "Utah", "Vermont", "Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming"]
-    },
-    {
-      "country": "Uruguay",
-      "states": ["Artigas", "Canelones", "Cerro Largo", "Colonia", "Durazno", "Flores", "Florida", "Lavalleja", "Maldonado", "Montevideo", "Paysandu", "Rio Negro", "Rivera", "Rocha", "Salto", "San Jose", "Soriano", "Tacuarembo", "Treinta y Tres"]
-    },
-    {
-      "country": "Uzbekistan",
-      "states": ["Andijon Viloyati", "Buxoro Viloyati", "Farg'ona Viloyati", "Jizzax Viloyati", "Namangan Viloyati", "Navoiy Viloyati", "Qashqadaryo Viloyati", "Qaraqalpog'iston Respublikasi", "Samarqand Viloyati", "Sirdaryo Viloyati", "Surxondaryo Viloyati", "Toshkent Shahri", "Toshkent Viloyati", "Xorazm Viloyati"]
-    },
-    {
-      "country": "Vanuatu",
-      "states": ["Malampa", "Penama", "Sanma", "Shefa", "Tafea", "Torba"]
-    },
-    {
-      "country": "Venezuela",
-      "states": ["Amazonas", "Anzoategui", "Apure", "Aragua", "Barinas", "Bolivar", "Carabobo", "Cojedes", "Delta Amacuro", "Dependencias Federales", "Distrito Federal", "Falcon", "Guarico", "Lara", "Merida", "Miranda", "Monagas", "Nueva Esparta", "Portuguesa", "Sucre", "Tachira", "Trujillo", "Vargas", "Yaracuy", "Zulia"]
-    },
-    {
-      "country": "Vietnam",
-      "states": ["An Giang", "Bac Giang", "Bac Kan", "Bac Lieu", "Bac Ninh", "Ba Ria-Vung Tau", "Ben Tre", "Binh Dinh", "Binh Duong", "Binh Phuoc", "Binh Thuan", "Ca Mau", "Cao Bang", "Dac Lak", "Dac Nong", "Dien Bien", "Dong Nai", "Dong Thap", "Gia Lai", "Ha Giang", "Hai Duong", "Ha Nam", "Ha Tay", "Ha Tinh", "Hau Giang", "Hoa Binh", "Hung Yen", "Khanh Hoa", "Kien Giang", "Kon Tum", "Lai Chau", "Lam Dong", "Lang Son", "Lao Cai", "Long An", "Nam Dinh", "Nghe An", "Ninh Binh", "Ninh Thuan", "Phu Tho", "Phu Yen", "Quang Binh", "Quang Nam", "Quang Ngai", "Quang Ninh", "Quang Tri", "Soc Trang", "Son La", "Tay Ninh", "Thai Binh", "Thai Nguyen", "Thanh Hoa", "Thua Thien-Hue", "Tien Giang", "Tra Vinh", "Tuyen Quang", "Vinh Long", "Vinh Phuc", "Yen Bai", "Can Tho", "Da Nang", "Hai Phong", "Hanoi", "Ho Chi Minh"]
-    },
-    {
-      "country": "Yemen",
-      "states": ["Abyan", "'Adan", "Ad Dali'", "Al Bayda'", "Al Hudaydah", "Al Jawf", "Al Mahrah", "Al Mahwit", "'Amran", "Dhamar", "Hadramawt", "Hajjah", "Ibb", "Lahij", "Ma'rib", "Sa'dah", "San'a'", "Shabwah", "Ta'izz"]
-    },
-    {
-      "country": "Zambia",
-      "states": ["Central", "Copperbelt", "Eastern", "Luapula", "Lusaka", "Northern", "North-Western", "Southern", "Western"]
-    },
-    {
-      "country": "Zimbabwe",
-      "states": ["Bulawayo", "Harare", "Manicaland", "Mashonaland Central", "Mashonaland East", "Mashonaland West", "Masvingo", "Matabeleland North", "Matabeleland South", "Midlands"]
-    }
-  ];
+    "states": [
+      "Aberconwy and Colwyn",
+      "Aberdeen City",
+      "Aberdeenshire",
+      "Anglesey",
+      "Angus",
+      "Antrim",
+      "Argyll and Bute",
+      "Armagh",
+      "Avon",
+      "Ayrshire",
+      "Bath and NE Somerset",
+      "Bedfordshire",
+      "Belfast",
+      "Berkshire",
+      "Berwickshire",
+      "BFPO",
+      "Blaenau Gwent",
+      "Buckinghamshire",
+      "Caernarfonshire",
+      "Caerphilly",
+      "Caithness",
+      "Cambridgeshire",
+      "Cardiff",
+      "Cardiganshire",
+      "Carmarthenshire",
+      "Ceredigion",
+      "Channel Islands",
+      "Cheshire",
+      "City of Bristol",
+      "Clackmannanshire",
+      "Clwyd",
+      "Conwy",
+      "Cornwall/Scilly",
+      "Cumbria",
+      "Denbighshire",
+      "Derbyshire",
+      "Derry/Londonderry",
+      "Devon",
+      "Dorset",
+      "Down",
+      "Dumfries and Galloway",
+      "Dunbartonshire",
+      "Dundee",
+      "Durham",
+      "Dyfed",
+      "East Ayrshire",
+      "East Dunbartonshire",
+      "East Lothian",
+      "East Renfrewshire",
+      "East Riding Yorkshire",
+      "East Sussex",
+      "Edinburgh",
+      "England",
+      "Essex",
+      "Falkirk",
+      "Fermanagh",
+      "Fife",
+      "Flintshire",
+      "Glasgow",
+      "Gloucestershire",
+      "Greater London",
+      "Greater Manchester",
+      "Gwent",
+      "Gwynedd",
+      "Hampshire",
+      "Hartlepool",
+      "Hereford and Worcester",
+      "Hertfordshire",
+      "Highlands",
+      "Inverclyde",
+      "Inverness-Shire",
+      "Isle of Man",
+      "Isle of Wight",
+      "Kent",
+      "Kincardinshire",
+      "Kingston Upon Hull",
+      "Kinross-Shire",
+      "Kirklees",
+      "Lanarkshire",
+      "Lancashire",
+      "Leicestershire",
+      "Lincolnshire",
+      "Londonderry",
+      "Merseyside",
+      "Merthyr Tydfil",
+      "Mid Glamorgan",
+      "Mid Lothian",
+      "Middlesex",
+      "Monmouthshire",
+      "Moray",
+      "Neath & Port Talbot",
+      "Newport",
+      "Norfolk",
+      "North Ayrshire",
+      "North East Lincolnshire",
+      "North Lanarkshire",
+      "North Lincolnshire",
+      "North Somerset",
+      "North Yorkshire",
+      "Northamptonshire",
+      "Northern Ireland",
+      "Northumberland",
+      "Nottinghamshire",
+      "Orkney and Shetland Isles",
+      "Oxfordshire",
+      "Pembrokeshire",
+      "Perth and Kinross",
+      "Powys",
+      "Redcar and Cleveland",
+      "Renfrewshire",
+      "Rhonda Cynon Taff",
+      "Rutland",
+      "Scottish Borders",
+      "Shetland",
+      "Shropshire",
+      "Somerset",
+      "South Ayrshire",
+      "South Glamorgan",
+      "South Gloucesteshire",
+      "South Lanarkshire",
+      "South Yorkshire",
+      "Staffordshire",
+      "Stirling",
+      "Stockton On Tees",
+      "Suffolk",
+      "Surrey",
+      "Swansea",
+      "Torfaen",
+      "Tyne and Wear",
+      "Tyrone",
+      "Vale Of Glamorgan",
+      "Wales",
+      "Warwickshire",
+      "West Berkshire",
+      "West Dunbartonshire",
+      "West Glamorgan",
+      "West Lothian",
+      "West Midlands",
+      "West Sussex",
+      "West Yorkshire",
+      "Western Isles",
+      "Wiltshire",
+      "Wirral",
+      "Worcestershire",
+      "Wrexham",
+      "York"
+    ],
+    "country_code": "GB"
+  },
+  {
+    "country": "Mexico",
+    "states": [
+      "Aguascalientes",
+      "Baja California",
+      "Baja California Sur",
+      "Campeche",
+      "Chiapas",
+      "Chihuahua",
+      "Coahuila de Zaragoza",
+      "Colima",
+      "Distrito Federal",
+      "Durango",
+      "Guanajuato",
+      "Guerrero",
+      "Hidalgo",
+      "Jalisco",
+      "Mexico",
+      "Michoacan de Ocampo",
+      "Morelos",
+      "Nayarit",
+      "Nuevo Leon",
+      "Oaxaca",
+      "Puebla",
+      "Queretaro de Arteaga",
+      "Quintana Roo",
+      "San Luis Potosi",
+      "Sinaloa",
+      "Sonora",
+      "Tabasco",
+      "Tamaulipas",
+      "Tlaxcala",
+      "Veracruz-Llave",
+      "Yucatan",
+      "Zacatecas"
+    ],
+    "country_code": "MX"
+  },
+  {
+    "country": "Afghanistan",
+    "states": [
+      "Badakhshan",
+      "Badghis",
+      "Baghlan",
+      "Balkh",
+      "Bamian",
+      "Daykondi",
+      "Farah",
+      "Faryab",
+      "Ghazni",
+      "Ghowr",
+      "Helmand",
+      "Herat",
+      "Jowzjan",
+      "Kabul",
+      "Kandahar",
+      "Kapisa",
+      "Khost",
+      "Konar",
+      "Kondoz",
+      "Laghman",
+      "Lowgar",
+      "Nangarhar",
+      "Nimruz",
+      "Nurestan",
+      "Oruzgan",
+      "Paktia",
+      "Paktika",
+      "Panjshir",
+      "Parvan",
+      "Samangan",
+      "Sar-e Pol",
+      "Takhar",
+      "Vardak",
+      "Zabol"
+    ],
+    "country_code": "AF"
+  },
+  {
+    "country": "Albania",
+    "states": [
+      "Berat",
+      "Dibres",
+      "Durres",
+      "Elbasan",
+      "Fier",
+      "Gjirokastre",
+      "Korce",
+      "Kukes",
+      "Lezhe",
+      "Shkoder",
+      "Tirane",
+      "Vlore"
+    ],
+    "country_code": "AL"
+  },
+  {
+    "country": "Algeria",
+    "states": [
+      "Adrar",
+      "Ain Defla",
+      "Ain Temouchent",
+      "Alger",
+      "Annaba",
+      "Batna",
+      "Bechar",
+      "Bejaia",
+      "Biskra",
+      "Blida",
+      "Bordj Bou Arreridj",
+      "Bouira",
+      "Boumerdes",
+      "Chlef",
+      "Constantine",
+      "Djelfa",
+      "El Bayadh",
+      "El Oued",
+      "El Tarf",
+      "Ghardaia",
+      "Guelma",
+      "Illizi",
+      "Jijel",
+      "Khenchela",
+      "Laghouat",
+      "Muaskar",
+      "Medea",
+      "Mila",
+      "Mostaganem",
+      "M'Sila",
+      "Naama",
+      "Oran",
+      "Ouargla",
+      "Oum el Bouaghi",
+      "Relizane",
+      "Saida",
+      "Setif",
+      "Sidi Bel Abbes",
+      "Skikda",
+      "Souk Ahras",
+      "Tamanghasset",
+      "Tebessa",
+      "Tiaret",
+      "Tindouf",
+      "Tipaza",
+      "Tissemsilt",
+      "Tizi Ouzou",
+      "Tlemcen"
+    ],
+    "country_code": "DZ"
+  },
+  {
+    "country": "Andorra",
+    "states": [
+      "Andorra la Vella",
+      "Canillo",
+      "Encamp",
+      "Escaldes-Engordany",
+      "La Massana",
+      "Ordino",
+      "Sant Julia de Loria"
+    ],
+    "country_code": "AD"
+  },
+  {
+    "country": "Angola",
+    "states": [
+      "Bengo",
+      "Benguela",
+      "Bie",
+      "Cabinda",
+      "Cuando Cubango",
+      "Cuanza Norte",
+      "Cuanza Sul",
+      "Cunene",
+      "Huambo",
+      "Huila",
+      "Luanda",
+      "Lunda Norte",
+      "Lunda Sul",
+      "Malanje",
+      "Moxico",
+      "Namibe",
+      "Uige",
+      "Zaire"
+    ],
+    "country_code": "AO"
+  },
+  {
+    "country": "Antarctica",
+    "states": [],
+    "country_code": "AQ"
+  },
+  {
+    "country": "Antigua and Barbuda",
+    "states": [
+      "Barbuda",
+      "Redonda",
+      "Saint George",
+      "Saint John",
+      "Saint Mary",
+      "Saint Paul",
+      "Saint Peter",
+      "Saint Philip"
+    ],
+    "country_code": "AG"
+  },
+  {
+    "country": "Argentina",
+    "states": [
+      "Buenos Aires",
+      "Buenos Aires Capital",
+      "Catamarca",
+      "Chaco",
+      "Chubut",
+      "Cordoba",
+      "Corrientes",
+      "Entre Rios",
+      "Formosa",
+      "Jujuy",
+      "La Pampa",
+      "La Rioja",
+      "Mendoza",
+      "Misiones",
+      "Neuquen",
+      "Rio Negro",
+      "Salta",
+      "San Juan",
+      "San Luis",
+      "Santa Cruz",
+      "Santa Fe",
+      "Santiago del Estero",
+      "Tierra del Fuego",
+      "Tucuman"
+    ],
+    "country_code": "AR"
+  },
+  {
+    "country": "Armenia",
+    "states": [
+      "Aragatsotn",
+      "Ararat",
+      "Armavir",
+      "Geghark'unik'",
+      "Kotayk'",
+      "Lorri",
+      "Shirak",
+      "Syunik'",
+      "Tavush",
+      "Vayots' Dzor",
+      "Yerevan"
+    ],
+    "country_code": "AM"
+  },
+  {
+    "country": "Australia",
+    "states": [
+      "Australian Capital Territory",
+      "New South Wales",
+      "Northern Territory",
+      "Queensland",
+      "South Australia",
+      "Tasmania",
+      "Victoria",
+      "Western Australia"
+    ],
+    "country_code": "AU"
+  },
+  {
+    "country": "Austria",
+    "states": [
+      "Burgenland",
+      "Kaernten",
+      "Niederoesterreich",
+      "Oberoesterreich",
+      "Salzburg",
+      "Steiermark",
+      "Tirol",
+      "Vorarlberg",
+      "Wien"
+    ],
+    "country_code": "AT"
+  },
+  {
+    "country": "Azerbaijan",
+    "states": [
+      "Abseron Rayonu",
+      "Agcabadi Rayonu",
+      "Agdam Rayonu",
+      "Agdas Rayonu",
+      "Agstafa Rayonu",
+      "Agsu Rayonu",
+      "Astara Rayonu",
+      "Balakan Rayonu",
+      "Barda Rayonu",
+      "Beylaqan Rayonu",
+      "Bilasuvar Rayonu",
+      "Cabrayil Rayonu",
+      "Calilabad Rayonu",
+      "Daskasan Rayonu",
+      "Davaci Rayonu",
+      "Fuzuli Rayonu",
+      "Gadabay Rayonu",
+      "Goranboy Rayonu",
+      "Goycay Rayonu",
+      "Haciqabul Rayonu",
+      "Imisli Rayonu",
+      "Ismayilli Rayonu",
+      "Kalbacar Rayonu",
+      "Kurdamir Rayonu",
+      "Lacin Rayonu",
+      "Lankaran Rayonu",
+      "Lerik Rayonu",
+      "Masalli Rayonu",
+      "Neftcala Rayonu",
+      "Oguz Rayonu",
+      "Qabala Rayonu",
+      "Qax Rayonu",
+      "Qazax Rayonu",
+      "Qobustan Rayonu",
+      "Quba Rayonu",
+      "Qubadli Rayonu",
+      "Qusar Rayonu",
+      "Saatli Rayonu",
+      "Sabirabad Rayonu",
+      "Saki Rayonu",
+      "Salyan Rayonu",
+      "Samaxi Rayonu",
+      "Samkir Rayonu",
+      "Samux Rayonu",
+      "Siyazan Rayonu",
+      "Susa Rayonu",
+      "Tartar Rayonu",
+      "Tovuz Rayonu",
+      "Ucar Rayonu",
+      "Xacmaz Rayonu",
+      "Xanlar Rayonu",
+      "Xizi Rayonu",
+      "Xocali Rayonu",
+      "Xocavand Rayonu",
+      "Yardimli Rayonu",
+      "Yevlax Rayonu",
+      "Zangilan Rayonu",
+      "Zaqatala Rayonu",
+      "Zardab Rayonu",
+      "Ali Bayramli Sahari",
+      "Baki Sahari",
+      "Ganca Sahari",
+      "Lankaran Sahari",
+      "Mingacevir Sahari",
+      "Naftalan Sahari",
+      "Saki Sahari",
+      "Sumqayit Sahari",
+      "Susa Sahari",
+      "Xankandi Sahari",
+      "Yevlax Sahari",
+      "Naxcivan Muxtar"
+    ],
+    "country_code": "AZ"
+  },
+  {
+    "country": "Bahamas",
+    "states": [
+      "Acklins and Crooked Islands",
+      "Bimini",
+      "Cat Island",
+      "Exuma",
+      "Freeport",
+      "Fresh Creek",
+      "Governor's Harbour",
+      "Green Turtle Cay",
+      "Harbour Island",
+      "High Rock",
+      "Inagua",
+      "Kemps Bay",
+      "Long Island",
+      "Marsh Harbour",
+      "Mayaguana",
+      "New Providence",
+      "Nichollstown and Berry Islands",
+      "Ragged Island",
+      "Rock Sound",
+      "Sandy Point",
+      "San Salvador and Rum Cay"
+    ],
+    "country_code": "BS"
+  },
+  {
+    "country": "Bahrain",
+    "states": [
+      "Al Hadd",
+      "Al Manamah",
+      "Al Mintaqah al Gharbiyah",
+      "Al Mintaqah al Wusta",
+      "Al Mintaqah ash Shamaliyah",
+      "Al Muharraq",
+      "Ar Rifa' wa al Mintaqah al Janubiyah",
+      "Jidd Hafs",
+      "Madinat Hamad",
+      "Madinat 'Isa",
+      "Juzur Hawar",
+      "Sitrah"
+    ],
+    "country_code": "BH"
+  },
+  {
+    "country": "Bangladesh",
+    "states": [
+      "Barisal",
+      "Chittagong",
+      "Dhaka",
+      "Khulna",
+      "Rajshahi",
+      "Sylhet"
+    ],
+    "country_code": "BD"
+  },
+  {
+    "country": "Barbados",
+    "states": [
+      "Christ Church",
+      "Saint Andrew",
+      "Saint George",
+      "Saint James",
+      "Saint John",
+      "Saint Joseph",
+      "Saint Lucy",
+      "Saint Michael",
+      "Saint Peter",
+      "Saint Philip",
+      "Saint Thomas"
+    ],
+    "country_code": "BB"
+  },
+  {
+    "country": "Belarus",
+    "states": [
+      "Brest",
+      "Homyel",
+      "Horad Minsk",
+      "Hrodna",
+      "Mahilyow",
+      "Minsk",
+      "Vitsyebsk"
+    ],
+    "country_code": "BY"
+  },
+  {
+    "country": "Belgium",
+    "states": [
+      "Antwerpen",
+      "Brabant Wallon",
+      "Brussels",
+      "Flanders",
+      "Hainaut",
+      "Liege",
+      "Limburg",
+      "Luxembourg",
+      "Namur",
+      "Oost-Vlaanderen",
+      "Vlaams-Brabant",
+      "Wallonia",
+      "West-Vlaanderen"
+    ],
+    "country_code": "BE"
+  },
+  {
+    "country": "Belize",
+    "states": [
+      "Belize",
+      "Cayo",
+      "Corozal",
+      "Orange Walk",
+      "Stann Creek",
+      "Toledo"
+    ],
+    "country_code": "BZ"
+  },
+  {
+    "country": "Benin",
+    "states": [
+      "Alibori",
+      "Atakora",
+      "Atlantique",
+      "Borgou",
+      "Collines",
+      "Donga",
+      "Kouffo",
+      "Littoral",
+      "Mono",
+      "Oueme",
+      "Plateau",
+      "Zou"
+    ],
+    "country_code": "BJ"
+  },
+  {
+    "country": "Bermuda",
+    "states": [
+      "Devonshire",
+      "Hamilton",
+      "Hamilton",
+      "Paget",
+      "Pembroke",
+      "Saint George",
+      "Saint George's",
+      "Sandys",
+      "Smith's",
+      "Southampton",
+      "Warwick"
+    ],
+    "country_code": "BM"
+  },
+  {
+    "country": "Bhutan",
+    "states": [
+      "Bumthang",
+      "Chukha",
+      "Dagana",
+      "Gasa",
+      "Haa",
+      "Lhuntse",
+      "Mongar",
+      "Paro",
+      "Pemagatshel",
+      "Punakha",
+      "Samdrup Jongkhar",
+      "Samtse",
+      "Sarpang",
+      "Thimphu",
+      "Trashigang",
+      "Trashiyangste",
+      "Trongsa",
+      "Tsirang",
+      "Wangdue Phodrang",
+      "Zhemgang"
+    ],
+    "country_code": "BT"
+  },
+  {
+    "country": "Bolivia",
+    "states": [
+      "Chuquisaca",
+      "Cochabamba",
+      "Beni",
+      "La Paz",
+      "Oruro",
+      "Pando",
+      "Potosi",
+      "Santa Cruz",
+      "Tarija"
+    ],
+    "country_code": "BO"
+  },
+  {
+    "country": "Bosnia and Herzegovina",
+    "states": [
+      "Una-Sana [Federation]",
+      "Posavina [Federation]",
+      "Tuzla [Federation]",
+      "Zenica-Doboj [Federation]",
+      "Bosnian Podrinje [Federation]",
+      "Central Bosnia [Federation]",
+      "Herzegovina-Neretva [Federation]",
+      "West Herzegovina [Federation]",
+      "Sarajevo [Federation]",
+      " West Bosnia [Federation]",
+      "Banja Luka [RS]",
+      "Bijeljina [RS]",
+      "Doboj [RS]",
+      "Fo?a [RS]",
+      "Sarajevo-Romanija [RS]",
+      "Trebinje [RS]",
+      "Vlasenica [RS]"
+    ],
+    "country_code": "BA"
+  },
+  {
+    "country": "Botswana",
+    "states": [
+      "Central",
+      "Ghanzi",
+      "Kgalagadi",
+      "Kgatleng",
+      "Kweneng",
+      "North East",
+      "North West",
+      "South East",
+      "Southern"
+    ],
+    "country_code": "BW"
+  },
+  {
+    "country": "Brazil",
+    "states": [
+      "Acre",
+      "Alagoas",
+      "Amapa",
+      "Amazonas",
+      "Bahia",
+      "Ceara",
+      "Distrito Federal",
+      "Espirito Santo",
+      "Goias",
+      "Maranhao",
+      "Mato Grosso",
+      "Mato Grosso do Sul",
+      "Minas Gerais",
+      "Para",
+      "Paraiba",
+      "Parana",
+      "Pernambuco",
+      "Piaui",
+      "Rio de Janeiro",
+      "Rio Grande do Norte",
+      "Rio Grande do Sul",
+      "Rondonia",
+      "Roraima",
+      "Santa Catarina",
+      "Sao Paulo",
+      "Sergipe",
+      "Tocantins"
+    ],
+    "country_code": "BR"
+  },
+  {
+    "country": "Brunei",
+    "states": [
+      "Belait",
+      "Brunei and Muara",
+      "Temburong",
+      "Tutong"
+    ],
+    "country_code": "BN"
+  },
+  {
+    "country": "Bulgaria",
+    "states": [
+      "Blagoevgrad",
+      "Burgas",
+      "Dobrich",
+      "Gabrovo",
+      "Khaskovo",
+      "Kurdzhali",
+      "Kyustendil",
+      "Lovech",
+      "Montana",
+      "Pazardzhik",
+      "Pernik",
+      "Pleven",
+      "Plovdiv",
+      "Razgrad",
+      "Ruse",
+      "Shumen",
+      "Silistra",
+      "Sliven",
+      "Smolyan",
+      "Sofiya",
+      "Sofiya-Grad",
+      "Stara Zagora",
+      "Turgovishte",
+      "Varna",
+      "Veliko Turnovo",
+      "Vidin",
+      "Vratsa",
+      "Yambol"
+    ],
+    "country_code": "BG"
+  },
+  {
+    "country": "Burkina Faso",
+    "states": [
+      "Bale",
+      "Bam",
+      "Banwa",
+      "Bazega",
+      "Bougouriba",
+      "Boulgou",
+      "Boulkiemde",
+      "Comoe",
+      "Ganzourgou",
+      "Gnagna",
+      "Gourma",
+      "Houet",
+      "Ioba",
+      "Kadiogo",
+      "Kenedougou",
+      "Komondjari",
+      "Kompienga",
+      "Kossi",
+      "Koulpelogo",
+      "Kouritenga",
+      "Kourweogo",
+      "Leraba",
+      "Loroum",
+      "Mouhoun",
+      "Namentenga",
+      "Nahouri",
+      "Nayala",
+      "Noumbiel",
+      "Oubritenga",
+      "Oudalan",
+      "Passore",
+      "Poni",
+      "Sanguie",
+      "Sanmatenga",
+      "Seno",
+      "Sissili",
+      "Soum",
+      "Sourou",
+      "Tapoa",
+      "Tuy",
+      "Yagha",
+      "Yatenga",
+      "Ziro",
+      "Zondoma",
+      "Zoundweogo"
+    ],
+    "country_code": "BF"
+  },
+  {
+    "country": "Burma",
+    "states": [
+      "Ayeyarwady",
+      "Bago",
+      "Magway",
+      "Mandalay",
+      "Sagaing",
+      "Tanintharyi",
+      "Yangon",
+      "Chin State",
+      "Kachin State",
+      "Kayin State",
+      "Kayah State",
+      "Mon State",
+      "Rakhine State",
+      "Shan State"
+    ],
+    "country_code": "MM"
+  },
+  {
+    "country": "Burundi",
+    "states": [
+      "Bubanza",
+      "Bujumbura Mairie",
+      "Bujumbura Rural",
+      "Bururi",
+      "Cankuzo",
+      "Cibitoke",
+      "Gitega",
+      "Karuzi",
+      "Kayanza",
+      "Kirundo",
+      "Makamba",
+      "Muramvya",
+      "Muyinga",
+      "Mwaro",
+      "Ngozi",
+      "Rutana",
+      "Ruyigi"
+    ],
+    "country_code": "BI"
+  },
+  {
+    "country": "Cambodia",
+    "states": [
+      "Banteay Mean Chey",
+      "Batdambang",
+      "Kampong Cham",
+      "Kampong Chhnang",
+      "Kampong Spoe",
+      "Kampong Thum",
+      "Kampot",
+      "Kandal",
+      "Koh Kong",
+      "Kracheh",
+      "Mondol Kiri",
+      "Otdar Mean Chey",
+      "Pouthisat",
+      "Preah Vihear",
+      "Prey Veng",
+      "Rotanakir",
+      "Siem Reab",
+      "Stoeng Treng",
+      "Svay Rieng",
+      "Takao",
+      "Keb",
+      "Pailin",
+      "Phnom Penh",
+      "Preah Seihanu"
+    ],
+    "country_code": "KH"
+  },
+  {
+    "country": "Cameroon",
+    "states": [
+      "Adamaoua",
+      "Centre",
+      "Est",
+      "Extreme-Nord",
+      "Littoral",
+      "Nord",
+      "Nord-Ouest",
+      "Ouest",
+      "Sud",
+      "Sud-Ouest"
+    ],
+    "country_code": "CM"
+  },
+  {
+    "country": "Canada",
+    "states": [
+      "Alberta",
+      "British Columbia",
+      "Manitoba",
+      "New Brunswick",
+      "Newfoundland and Labrador",
+      "Northwest Territories",
+      "Nova Scotia",
+      "Nunavut",
+      "Ontario",
+      "Prince Edward Island",
+      "Quebec",
+      "Saskatchewan",
+      "Yukon Territory"
+    ],
+    "country_code": "CA"
+  },
+  {
+    "country": "Cape Verde",
+    "states": [],
+    "country_code": "CV"
+  },
+  {
+    "country": "Central African Republic",
+    "states": [
+      "Bamingui-Bangoran",
+      "Bangui",
+      "Basse-Kotto",
+      "Haute-Kotto",
+      "Haut-Mbomou",
+      "Kemo",
+      "Lobaye",
+      "Mambere-Kadei",
+      "Mbomou",
+      "Nana-Grebizi",
+      "Nana-Mambere",
+      "Ombella-Mpoko",
+      "Ouaka",
+      "Ouham",
+      "Ouham-Pende",
+      "Sangha-Mbaere",
+      "Vakaga"
+    ],
+    "country_code": "CF"
+  },
+  {
+    "country": "Chad",
+    "states": [
+      "Batha",
+      "Biltine",
+      "Borkou-Ennedi-Tibesti",
+      "Chari-Baguirmi",
+      "Gu\u00e9ra",
+      "Kanem",
+      "Lac",
+      "Logone Occidental",
+      "Logone Oriental",
+      "Mayo-Kebbi",
+      "Moyen-Chari",
+      "Ouadda\u00ef",
+      "Salamat",
+      "Tandjile"
+    ],
+    "country_code": "TD"
+  },
+  {
+    "country": "Chile",
+    "states": [
+      "Aysen",
+      "Antofagasta",
+      "Araucania",
+      "Atacama",
+      "Bio-Bio",
+      "Coquimbo",
+      "O'Higgins",
+      "Los Lagos",
+      "Magallanes y la Antartica Chilena",
+      "Maule",
+      "Santiago Region Metropolitana",
+      "Tarapaca",
+      "Valparaiso"
+    ],
+    "country_code": "CL"
+  },
+  {
+    "country": "China",
+    "states": [
+      "Anhui",
+      "Fujian",
+      "Gansu",
+      "Guangdong",
+      "Guizhou",
+      "Hainan",
+      "Hebei",
+      "Heilongjiang",
+      "Henan",
+      "Hubei",
+      "Hunan",
+      "Jiangsu",
+      "Jiangxi",
+      "Jilin",
+      "Liaoning",
+      "Qinghai",
+      "Shaanxi",
+      "Shandong",
+      "Shanxi",
+      "Sichuan",
+      "Yunnan",
+      "Zhejiang",
+      "Guangxi",
+      "Nei Mongol",
+      "Ningxia",
+      "Xinjiang",
+      "Xizang (Tibet)",
+      "Beijing",
+      "Chongqing",
+      "Shanghai",
+      "Tianjin"
+    ],
+    "country_code": "CN"
+  },
+  {
+    "country": "Colombia",
+    "states": [
+      "Amazonas",
+      "Antioquia",
+      "Arauca",
+      "Atlantico",
+      "Bogota District Capital",
+      "Bolivar",
+      "Boyaca",
+      "Caldas",
+      "Caqueta",
+      "Casanare",
+      "Cauca",
+      "Cesar",
+      "Choco",
+      "Cordoba",
+      "Cundinamarca",
+      "Guainia",
+      "Guaviare",
+      "Huila",
+      "La Guajira",
+      "Magdalena",
+      "Meta",
+      "Narino",
+      "Norte de Santander",
+      "Putumayo",
+      "Quindio",
+      "Risaralda",
+      "San Andres & Providencia",
+      "Santander",
+      "Sucre",
+      "Tolima",
+      "Valle del Cauca",
+      "Vaupes",
+      "Vichada"
+    ],
+    "country_code": "CO"
+  },
+  {
+    "country": "Comoros",
+    "states": [
+      "Grande Comore (Njazidja)",
+      "Anjouan (Nzwani)",
+      "Moheli (Mwali)"
+    ],
+    "country_code": "KM"
+  },
+  {
+    "country": "Congo, Democratic Republic",
+    "states": [
+      "Bandundu",
+      "Bas-Congo",
+      "Equateur",
+      "Kasai-Occidental",
+      "Kasai-Oriental",
+      "Katanga",
+      "Kinshasa",
+      "Maniema",
+      "Nord-Kivu",
+      "Orientale",
+      "Sud-Kivu"
+    ],
+    "country_code": "CD"
+  },
+  {
+    "country": "Congo, Republic of the",
+    "states": [
+      "Bouenza",
+      "Brazzaville",
+      "Cuvette",
+      "Cuvette-Ouest",
+      "Kouilou",
+      "Lekoumou",
+      "Likouala",
+      "Niari",
+      "Plateaux",
+      "Pool",
+      "Sangha"
+    ],
+    "country_code": "CG"
+  },
+  {
+    "country": "Costa Rica",
+    "states": [
+      "Alajuela",
+      "Cartago",
+      "Guanacaste",
+      "Heredia",
+      "Limon",
+      "Puntarenas",
+      "San Jose"
+    ],
+    "country_code": "CR"
+  },
+  {
+    "country": "Cote d'Ivoire",
+    "states": [],
+    "country_code": "CI"
+  },
+  {
+    "country": "Croatia",
+    "states": [
+      "Bjelovarsko-Bilogorska",
+      "Brodsko-Posavska",
+      "Dubrovacko-Neretvanska",
+      "Istarska",
+      "Karlovacka",
+      "Koprivnicko-Krizevacka",
+      "Krapinsko-Zagorska",
+      "Licko-Senjska",
+      "Medimurska",
+      "Osjecko-Baranjska",
+      "Pozesko-Slavonska",
+      "Primorsko-Goranska",
+      "Sibensko-Kninska",
+      "Sisacko-Moslavacka",
+      "Splitsko-Dalmatinska",
+      "Varazdinska",
+      "Viroviticko-Podravska",
+      "Vukovarsko-Srijemska",
+      "Zadarska",
+      "Zagreb",
+      "Zagrebacka"
+    ],
+    "country_code": "HR"
+  },
+  {
+    "country": "Cuba",
+    "states": [
+      "Camaguey",
+      "Ciego de Avila",
+      "Cienfuegos",
+      "Ciudad de La Habana",
+      "Granma",
+      "Guantanamo",
+      "Holguin",
+      "Isla de la Juventud",
+      "La Habana",
+      "Las Tunas",
+      "Matanzas",
+      "Pinar del Rio",
+      "Sancti Spiritus",
+      "Santiago de Cuba",
+      "Villa Clara"
+    ],
+    "country_code": "CU"
+  },
+  {
+    "country": "Cyprus",
+    "states": [
+      "Famagusta",
+      "Kyrenia",
+      "Larnaca",
+      "Limassol",
+      "Nicosia",
+      "Paphos"
+    ],
+    "country_code": "CY"
+  },
+  {
+    "country": "Czech Republic",
+    "states": [
+      "Jihocesky Kraj",
+      "Jihomoravsky Kraj",
+      "Karlovarsky Kraj",
+      "Kralovehradecky Kraj",
+      "Liberecky Kraj",
+      "Moravskoslezsky Kraj",
+      "Olomoucky Kraj",
+      "Pardubicky Kraj",
+      "Plzensky Kraj",
+      "Praha",
+      "Stredocesky Kraj",
+      "Ustecky Kraj",
+      "Vysocina",
+      "Zlinsky Kraj"
+    ],
+    "country_code": "CZ"
+  },
+  {
+    "country": "Denmark",
+    "states": [
+      "Arhus",
+      "Bornholm",
+      "Frederiksberg",
+      "Frederiksborg",
+      "Fyn",
+      "Kobenhavn",
+      "Kobenhavns",
+      "Nordjylland",
+      "Ribe",
+      "Ringkobing",
+      "Roskilde",
+      "Sonderjylland",
+      "Storstrom",
+      "Vejle",
+      "Vestsjalland",
+      "Viborg"
+    ],
+    "country_code": "DK"
+  },
+  {
+    "country": "Djibouti",
+    "states": [
+      "Ali Sabih",
+      "Dikhil",
+      "Djibouti",
+      "Obock",
+      "Tadjoura"
+    ],
+    "country_code": "DJ"
+  },
+  {
+    "country": "Dominica",
+    "states": [
+      "Saint Andrew",
+      "Saint David",
+      "Saint George",
+      "Saint John",
+      "Saint Joseph",
+      "Saint Luke",
+      "Saint Mark",
+      "Saint Patrick",
+      "Saint Paul",
+      "Saint Peter"
+    ],
+    "country_code": "DM"
+  },
+  {
+    "country": "Dominican Republic",
+    "states": [
+      "Azua",
+      "Baoruco",
+      "Barahona",
+      "Dajabon",
+      "Distrito Nacional",
+      "Duarte",
+      "Elias Pina",
+      "El Seibo",
+      "Espaillat",
+      "Hato Mayor",
+      "Independencia",
+      "La Altagracia",
+      "La Romana",
+      "La Vega",
+      "Maria Trinidad Sanchez",
+      "Monsenor Nouel",
+      "Monte Cristi",
+      "Monte Plata",
+      "Pedernales",
+      "Peravia",
+      "Puerto Plata",
+      "Salcedo",
+      "Samana",
+      "Sanchez Ramirez",
+      "San Cristobal",
+      "San Jose de Ocoa",
+      "San Juan",
+      "San Pedro de Macoris",
+      "Santiago",
+      "Santiago Rodriguez",
+      "Santo Domingo",
+      "Valverde"
+    ],
+    "country_code": "DO"
+  },
+  {
+    "country": "East Timor",
+    "states": [
+      "Aileu",
+      "Ainaro",
+      "Baucau",
+      "Bobonaro",
+      "Cova-Lima",
+      "Dili",
+      "Ermera",
+      "Lautem",
+      "Liquica",
+      "Manatuto",
+      "Manufahi",
+      "Oecussi",
+      "Viqueque"
+    ],
+    "country_code": "TL"
+  },
+  {
+    "country": "Ecuador",
+    "states": [
+      "Azuay",
+      "Bolivar",
+      "Canar",
+      "Carchi",
+      "Chimborazo",
+      "Cotopaxi",
+      "El Oro",
+      "Esmeraldas",
+      "Galapagos",
+      "Guayas",
+      "Imbabura",
+      "Loja",
+      "Los Rios",
+      "Manabi",
+      "Morona-Santiago",
+      "Napo",
+      "Orellana",
+      "Pastaza",
+      "Pichincha",
+      "Sucumbios",
+      "Tungurahua",
+      "Zamora-Chinchipe"
+    ],
+    "country_code": "EC"
+  },
+  {
+    "country": "Egypt",
+    "states": [
+      "Ad Daqahliyah",
+      "Al Bahr al Ahmar",
+      "Al Buhayrah",
+      "Al Fayyum",
+      "Al Gharbiyah",
+      "Al Iskandariyah",
+      "Al Isma'iliyah",
+      "Al Jizah",
+      "Al Minufiyah",
+      "Al Minya",
+      "Al Qahirah",
+      "Al Qalyubiyah",
+      "Al Wadi al Jadid",
+      "Ash Sharqiyah",
+      "As Suways",
+      "Aswan",
+      "Asyut",
+      "Bani Suwayf",
+      "Bur Sa'id",
+      "Dumyat",
+      "Janub Sina'",
+      "Kafr ash Shaykh",
+      "Matruh",
+      "Qina",
+      "Shamal Sina'",
+      "Suhaj"
+    ],
+    "country_code": "EG"
+  },
+  {
+    "country": "El Salvador",
+    "states": [
+      "Ahuachapan",
+      "Cabanas",
+      "Chalatenango",
+      "Cuscatlan",
+      "La Libertad",
+      "La Paz",
+      "La Union",
+      "Morazan",
+      "San Miguel",
+      "San Salvador",
+      "Santa Ana",
+      "San Vicente",
+      "Sonsonate",
+      "Usulutan"
+    ],
+    "country_code": "SV"
+  },
+  {
+    "country": "Equatorial Guinea",
+    "states": [
+      "Annobon",
+      "Bioko Norte",
+      "Bioko Sur",
+      "Centro Sur",
+      "Kie-Ntem",
+      "Litoral",
+      "Wele-Nzas"
+    ],
+    "country_code": "GQ"
+  },
+  {
+    "country": "Eritrea",
+    "states": [
+      "Anseba",
+      "Debub",
+      "Debubawi K'eyih Bahri",
+      "Gash Barka",
+      "Ma'akel",
+      "Semenawi Keyih Bahri"
+    ],
+    "country_code": "ER"
+  },
+  {
+    "country": "Estonia",
+    "states": [
+      "Harjumaa (Tallinn)",
+      "Hiiumaa (Kardla)",
+      "Ida-Virumaa (Johvi)",
+      "Jarvamaa (Paide)",
+      "Jogevamaa (Jogeva)",
+      "Laanemaa (Haapsalu)",
+      "Laane-Virumaa (Rakvere)",
+      "Parnumaa (Parnu)",
+      "Polvamaa (Polva)",
+      "Raplamaa (Rapla)",
+      "Saaremaa (Kuressaare)",
+      "Tartumaa (Tartu)",
+      "Valgamaa (Valga)",
+      "Viljandimaa (Viljandi)",
+      "Vorumaa (Voru)"
+    ],
+    "country_code": "EE"
+  },
+  {
+    "country": "Ethiopia",
+    "states": [
+      "Addis Ababa",
+      "Afar",
+      "Amhara",
+      "Binshangul Gumuz",
+      "Dire Dawa",
+      "Gambela Hizboch",
+      "Harari",
+      "Oromia",
+      "Somali",
+      "Tigray",
+      "Southern Nations, Nationalities, and Peoples Region"
+    ],
+    "country_code": "ET"
+  },
+  {
+    "country": "Fiji",
+    "states": [
+      "Central (Suva)",
+      "Eastern (Levuka)",
+      "Northern (Labasa)",
+      "Rotuma",
+      "Western (Lautoka)"
+    ],
+    "country_code": "FJ"
+  },
+  {
+    "country": "Finland",
+    "states": [
+      "Aland",
+      "Etela-Suomen Laani",
+      "Ita-Suomen Laani",
+      "Lansi-Suomen Laani",
+      "Lappi",
+      "Oulun Laani"
+    ],
+    "country_code": "FI"
+  },
+  {
+    "country": "France",
+    "states": [
+      "Alsace",
+      "Aquitaine",
+      "Auvergne",
+      "Basse-Normandie",
+      "Bourgogne",
+      "Bretagne",
+      "Centre",
+      "Champagne-Ardenne",
+      "Corse",
+      "Franche-Comte",
+      "Haute-Normandie",
+      "Ile-de-France",
+      "Languedoc-Roussillon",
+      "Limousin",
+      "Lorraine",
+      "Midi-Pyrenees",
+      "Nord-Pas-de-Calais",
+      "Pays de la Loire",
+      "Picardie",
+      "Poitou-Charentes",
+      "Provence-Alpes-Cote d'Azur",
+      "Rhone-Alpes"
+    ],
+    "country_code": "FR"
+  },
+  {
+    "country": "Gabon",
+    "states": [
+      "Estuaire",
+      "Haut-Ogooue",
+      "Moyen-Ogooue",
+      "Ngounie",
+      "Nyanga",
+      "Ogooue-Ivindo",
+      "Ogooue-Lolo",
+      "Ogooue-Maritime",
+      "Woleu-Ntem"
+    ],
+    "country_code": "GA"
+  },
+  {
+    "country": "Gambia",
+    "states": [
+      "Banjul",
+      "Central River",
+      "Lower River",
+      "North Bank",
+      "Upper River",
+      "Western"
+    ],
+    "country_code": "GM"
+  },
+  {
+    "country": "Georgia",
+    "states": [],
+    "country_code": "GE"
+  },
+  {
+    "country": "Germany",
+    "states": [
+      "Baden-Wuerttemberg",
+      "Bayern",
+      "Berlin",
+      "Brandenburg",
+      "Bremen",
+      "Hamburg",
+      "Hessen",
+      "Mecklenburg-Vorpommern",
+      "Niedersachsen",
+      "Nordrhein-Westfalen",
+      "Rheinland-Pfalz",
+      "Saarland",
+      "Sachsen",
+      "Sachsen-Anhalt",
+      "Schleswig-Holstein",
+      "Thueringen"
+    ],
+    "country_code": "DE"
+  },
+  {
+    "country": "Ghana",
+    "states": [
+      "Ashanti",
+      "Brong-Ahafo",
+      "Central",
+      "Eastern",
+      "Greater Accra",
+      "Northern",
+      "Upper East",
+      "Upper West",
+      "Volta",
+      "Western"
+    ],
+    "country_code": "GH"
+  },
+  {
+    "country": "Greece",
+    "states": [
+      "Agion Oros",
+      "Achaia",
+      "Aitolia kai Akarmania",
+      "Argolis",
+      "Arkadia",
+      "Arta",
+      "Attiki",
+      "Chalkidiki",
+      "Chanion",
+      "Chios",
+      "Dodekanisos",
+      "Drama",
+      "Evros",
+      "Evrytania",
+      "Evvoia",
+      "Florina",
+      "Fokidos",
+      "Fthiotis",
+      "Grevena",
+      "Ileia",
+      "Imathia",
+      "Ioannina",
+      "Irakleion",
+      "Karditsa",
+      "Kastoria",
+      "Kavala",
+      "Kefallinia",
+      "Kerkyra",
+      "Kilkis",
+      "Korinthia",
+      "Kozani",
+      "Kyklades",
+      "Lakonia",
+      "Larisa",
+      "Lasithi",
+      "Lefkas",
+      "Lesvos",
+      "Magnisia",
+      "Messinia",
+      "Pella",
+      "Pieria",
+      "Preveza",
+      "Rethynnis",
+      "Rodopi",
+      "Samos",
+      "Serrai",
+      "Thesprotia",
+      "Thessaloniki",
+      "Trikala",
+      "Voiotia",
+      "Xanthi",
+      "Zakynthos"
+    ],
+    "country_code": "GR"
+  },
+  {
+    "country": "Greenland",
+    "states": [
+      "Avannaa (Nordgronland)",
+      "Tunu (Ostgronland)",
+      "Kitaa (Vestgronland)"
+    ],
+    "country_code": "GL"
+  },
+  {
+    "country": "Grenada",
+    "states": [
+      "Carriacou and Petit Martinique",
+      "Saint Andrew",
+      "Saint David",
+      "Saint George",
+      "Saint John",
+      "Saint Mark",
+      "Saint Patrick"
+    ],
+    "country_code": "GD"
+  },
+  {
+    "country": "Guatemala",
+    "states": [
+      "Alta Verapaz",
+      "Baja Verapaz",
+      "Chimaltenango",
+      "Chiquimula",
+      "El Progreso",
+      "Escuintla",
+      "Guatemala",
+      "Huehuetenango",
+      "Izabal",
+      "Jalapa",
+      "Jutiapa",
+      "Peten",
+      "Quetzaltenango",
+      "Quiche",
+      "Retalhuleu",
+      "Sacatepequez",
+      "San Marcos",
+      "Santa Rosa",
+      "Solola",
+      "Suchitepequez",
+      "Totonicapan",
+      "Zacapa"
+    ],
+    "country_code": "GT"
+  },
+  {
+    "country": "Guinea",
+    "states": [
+      "Beyla",
+      "Boffa",
+      "Boke",
+      "Conakry",
+      "Coyah",
+      "Dabola",
+      "Dalaba",
+      "Dinguiraye",
+      "Dubreka",
+      "Faranah",
+      "Forecariah",
+      "Fria",
+      "Gaoual",
+      "Gueckedou",
+      "Kankan",
+      "Kerouane",
+      "Kindia",
+      "Kissidougou",
+      "Koubia",
+      "Koundara",
+      "Kouroussa",
+      "Labe",
+      "Lelouma",
+      "Lola",
+      "Macenta",
+      "Mali",
+      "Mamou",
+      "Mandiana",
+      "Nzerekore",
+      "Pita",
+      "Siguiri",
+      "Telimele",
+      "Tougue",
+      "Yomou"
+    ],
+    "country_code": "GN"
+  },
+  {
+    "country": "Guinea-Bissau",
+    "states": [
+      "Bafata",
+      "Biombo",
+      "Bissau",
+      "Bolama",
+      "Cacheu",
+      "Gabu",
+      "Oio",
+      "Quinara",
+      "Tombali"
+    ],
+    "country_code": "GW"
+  },
+  {
+    "country": "Guyana",
+    "states": [
+      "Barima-Waini",
+      "Cuyuni-Mazaruni",
+      "Demerara-Mahaica",
+      "East Berbice-Corentyne",
+      "Essequibo Islands-West Demerara",
+      "Mahaica-Berbice",
+      "Pomeroon-Supenaam",
+      "Potaro-Siparuni",
+      "Upper Demerara-Berbice",
+      "Upper Takutu-Upper Essequibo"
+    ],
+    "country_code": "GY"
+  },
+  {
+    "country": "Haiti",
+    "states": [
+      "Artibonite",
+      "Centre",
+      "Grand 'Anse",
+      "Nord",
+      "Nord-Est",
+      "Nord-Ouest",
+      "Ouest",
+      "Sud",
+      "Sud-Est"
+    ],
+    "country_code": "HT"
+  },
+  {
+    "country": "Honduras",
+    "states": [
+      "Atlantida",
+      "Choluteca",
+      "Colon",
+      "Comayagua",
+      "Copan",
+      "Cortes",
+      "El Paraiso",
+      "Francisco Morazan",
+      "Gracias a Dios",
+      "Intibuca",
+      "Islas de la Bahia",
+      "La Paz",
+      "Lempira",
+      "Ocotepeque",
+      "Olancho",
+      "Santa Barbara",
+      "Valle",
+      "Yoro"
+    ],
+    "country_code": "HN"
+  },
+  {
+    "country": "Hong Kong",
+    "states": [
+      "Yuen Long District",
+      "Tsuen Wan District",
+      "Tai Po District",
+      "Sai Kung District",
+      "Islands District",
+      "Central and Western District",
+      "Wan Chai",
+      "Eastern",
+      "Southern",
+      "North",
+      "Yau Tsim Mong",
+      "Sham Shui Po",
+      "Kowloon City",
+      "Wong Tai Sin",
+      "Kwun Tong",
+      "Kwai Tsing",
+      "Tuen Mun",
+      "Sha Tin"
+    ],
+    "country_code": "HK"
+  },
+  {
+    "country": "Hungary",
+    "states": [
+      "Bacs-Kiskun",
+      "Baranya",
+      "Bekes",
+      "Borsod-Abauj-Zemplen",
+      "Csongrad",
+      "Fejer",
+      "Gyor-Moson-Sopron",
+      "Hajdu-Bihar",
+      "Heves",
+      "Jasz-Nagykun-Szolnok",
+      "Komarom-Esztergom",
+      "Nograd",
+      "Pest",
+      "Somogy",
+      "Szabolcs-Szatmar-Bereg",
+      "Tolna",
+      "Vas",
+      "Veszprem",
+      "Zala"
+    ],
+    "country_code": "HU"
+  },
+  {
+    "country": "Iceland",
+    "states": [
+      "Austurland",
+      "Hofudhborgarsvaedhi",
+      "Nordhurland Eystra",
+      "Nordhurland Vestra",
+      "Sudhurland",
+      "Sudhurnes",
+      "Vestfirdhir",
+      "Vesturland"
+    ],
+    "country_code": "IS"
+  },
+  {
+    "country": "India",
+    "states": [
+      "Andaman and Nicobar Islands",
+      "Andhra Pradesh",
+      "Arunachal Pradesh",
+      "Assam",
+      "Bihar",
+      "Chandigarh",
+      "Chhattisgarh",
+      "Dadra and Nagar Haveli",
+      "Daman and Diu",
+      "Delhi",
+      "Goa",
+      "Gujarat",
+      "Haryana",
+      "Himachal Pradesh",
+      "Jammu and Kashmir",
+      "Jharkhand",
+      "Karnataka",
+      "Kerala",
+      "Ladakh",
+      "Lakshadweep",
+      "Madhya Pradesh",
+      "Maharashtra",
+      "Manipur",
+      "Meghalaya",
+      "Mizoram",
+      "Nagaland",
+      "Orissa",
+      "Pondicherry",
+      "Punjab",
+      "Rajasthan",
+      "Sikkim",
+      "Tamil Nadu",
+      "Telangana",
+      "Tripura",
+      "Uttaranchal",
+      "Uttar Pradesh",
+      "West Bengal"
+    ],
+    "country_code": "IN"
+  },
+  {
+    "country": "Indonesia",
+    "states": [
+      "Aceh",
+      "Bali",
+      "Banten",
+      "Bengkulu",
+      "Gorontalo",
+      "Irian Jaya Barat",
+      "Jakarta Raya",
+      "Jambi",
+      "Jawa Barat",
+      "Jawa Tengah",
+      "Jawa Timur",
+      "Kalimantan Barat",
+      "Kalimantan Selatan",
+      "Kalimantan Tengah",
+      "Kalimantan Timur",
+      "Kepulauan Bangka Belitung",
+      "Kepulauan Riau",
+      "Lampung",
+      "Maluku",
+      "Maluku Utara",
+      "Nusa Tenggara Barat",
+      "Nusa Tenggara Timur",
+      "Papua",
+      "Riau",
+      "Sulawesi Barat",
+      "Sulawesi Selatan",
+      "Sulawesi Tengah",
+      "Sulawesi Tenggara",
+      "Sulawesi Utara",
+      "Sumatera Barat",
+      "Sumatera Selatan",
+      "Sumatera Utara",
+      "Yogyakarta"
+    ],
+    "country_code": "ID"
+  },
+  {
+    "country": "Iran",
+    "states": [
+      "Ardabil",
+      "Azarbayjan-e Gharbi",
+      "Azarbayjan-e Sharqi",
+      "Bushehr",
+      "Chahar Mahall va Bakhtiari",
+      "Esfahan",
+      "Fars",
+      "Gilan",
+      "Golestan",
+      "Hamadan",
+      "Hormozgan",
+      "Ilam",
+      "Kerman",
+      "Kermanshah",
+      "Khorasan-e Janubi",
+      "Khorasan-e Razavi",
+      "Khorasan-e Shemali",
+      "Khuzestan",
+      "Kohgiluyeh va Buyer Ahmad",
+      "Kordestan",
+      "Lorestan",
+      "Markazi",
+      "Mazandaran",
+      "Qazvin",
+      "Qom",
+      "Semnan",
+      "Sistan va Baluchestan",
+      "Tehran",
+      "Yazd",
+      "Zanjan"
+    ],
+    "country_code": "IR"
+  },
+  {
+    "country": "Iraq",
+    "states": [
+      "Al Anbar",
+      "Al Basrah",
+      "Al Muthanna",
+      "Al Qadisiyah",
+      "An Najaf",
+      "Arbil",
+      "As Sulaymaniyah",
+      "At Ta'mim",
+      "Babil",
+      "Baghdad",
+      "Dahuk",
+      "Dhi Qar",
+      "Diyala",
+      "Karbala'",
+      "Maysan",
+      "Ninawa",
+      "Salah ad Din",
+      "Wasit"
+    ],
+    "country_code": "IQ"
+  },
+  {
+    "country": "Ireland",
+    "states": [
+      "Carlow",
+      "Cavan",
+      "Clare",
+      "Cork",
+      "Donegal",
+      "Dublin",
+      "Galway",
+      "Kerry",
+      "Kildare",
+      "Kilkenny",
+      "Laois",
+      "Leitrim",
+      "Limerick",
+      "Longford",
+      "Louth",
+      "Mayo",
+      "Meath",
+      "Monaghan",
+      "Offaly",
+      "Roscommon",
+      "Sligo",
+      "Tipperary",
+      "Waterford",
+      "Westmeath",
+      "Wexford",
+      "Wicklow"
+    ],
+    "country_code": "IE"
+  },
+  {
+    "country": "Israel",
+    "states": [
+      "Central",
+      "Haifa",
+      "Jerusalem",
+      "Northern",
+      "Southern",
+      "Tel Aviv"
+    ],
+    "country_code": "IL"
+  },
+  {
+    "country": "Italy",
+    "states": [
+      "Abruzzo",
+      "Basilicata",
+      "Calabria",
+      "Campania",
+      "Emilia-Romagna",
+      "Friuli-Venezia Giulia",
+      "Lazio",
+      "Liguria",
+      "Lombardia",
+      "Marche",
+      "Molise",
+      "Piemonte",
+      "Puglia",
+      "Sardegna",
+      "Sicilia",
+      "Toscana",
+      "Trentino-Alto Adige",
+      "Umbria",
+      "Valle d'Aosta",
+      "Veneto"
+    ],
+    "country_code": "IT"
+  },
+  {
+    "country": "Jamaica",
+    "states": [
+      "Clarendon",
+      "Hanover",
+      "Kingston",
+      "Manchester",
+      "Portland",
+      "Saint Andrew",
+      "Saint Ann",
+      "Saint Catherine",
+      "Saint Elizabeth",
+      "Saint James",
+      "Saint Mary",
+      "Saint Thomas",
+      "Trelawny",
+      "Westmoreland"
+    ],
+    "country_code": "JM"
+  },
+  {
+    "country": "Japan",
+    "states": [
+      "Aichi",
+      "Akita",
+      "Aomori",
+      "Chiba",
+      "Ehime",
+      "Fukui",
+      "Fukuoka",
+      "Fukushima",
+      "Gifu",
+      "Gumma",
+      "Hiroshima",
+      "Hokkaido",
+      "Hyogo",
+      "Ibaraki",
+      "Ishikawa",
+      "Iwate",
+      "Kagawa",
+      "Kagoshima",
+      "Kanagawa",
+      "Kochi",
+      "Kumamoto",
+      "Kyoto",
+      "Mie",
+      "Miyagi",
+      "Miyazaki",
+      "Nagano",
+      "Nagasaki",
+      "Nara",
+      "Niigata",
+      "Oita",
+      "Okayama",
+      "Okinawa",
+      "Osaka",
+      "Saga",
+      "Saitama",
+      "Shiga",
+      "Shimane",
+      "Shizuoka",
+      "Tochigi",
+      "Tokushima",
+      "Tokyo",
+      "Tottori",
+      "Toyama",
+      "Wakayama",
+      "Yamagata",
+      "Yamaguchi",
+      "Yamanashi"
+    ],
+    "country_code": "JP"
+  },
+  {
+    "country": "Jordan",
+    "states": [
+      "Ajlun",
+      "Al 'Aqabah",
+      "Al Balqa'",
+      "Al Karak",
+      "Al Mafraq",
+      "'Amman",
+      "At Tafilah",
+      "Az Zarqa'",
+      "Irbid",
+      "Jarash",
+      "Ma'an",
+      "Madaba"
+    ],
+    "country_code": "JO"
+  },
+  {
+    "country": "Kazakhstan",
+    "states": [
+      "Almaty Oblysy",
+      "Almaty Qalasy",
+      "Aqmola Oblysy",
+      "Aqtobe Oblysy",
+      "Astana Qalasy",
+      "Atyrau Oblysy",
+      "Batys Qazaqstan Oblysy",
+      "Bayqongyr Qalasy",
+      "Mangghystau Oblysy",
+      "Ongtustik Qazaqstan Oblysy",
+      "Pavlodar Oblysy",
+      "Qaraghandy Oblysy",
+      "Qostanay Oblysy",
+      "Qyzylorda Oblysy",
+      "Shyghys Qazaqstan Oblysy",
+      "Soltustik Qazaqstan Oblysy",
+      "Zhambyl Oblysy"
+    ],
+    "country_code": "KZ"
+  },
+  {
+    "country": "Kenya",
+    "states": [
+      "Central",
+      "Coast",
+      "Eastern",
+      "Nairobi Area",
+      "North Eastern",
+      "Nyanza",
+      "Rift Valley",
+      "Western"
+    ],
+    "country_code": "KE"
+  },
+  {
+    "country": "Kiribati",
+    "states": [],
+    "country_code": "KI"
+  },
+  {
+    "country": "Korea North",
+    "states": [
+      "Chagang",
+      "North Hamgyong",
+      "South Hamgyong",
+      "North Hwanghae",
+      "South Hwanghae",
+      "Kangwon",
+      "North P'yongan",
+      "South P'yongan",
+      "Yanggang",
+      "Kaesong",
+      "Najin",
+      "Namp'o",
+      "Pyongyang"
+    ],
+    "country_code": "KP"
+  },
+  {
+    "country": "Korea South",
+    "states": [
+      "Seoul",
+      "Busan City",
+      "Daegu City",
+      "Incheon City",
+      "Gwangju City",
+      "Daejeon City",
+      "Ulsan",
+      "Gyeonggi Province",
+      "Gangwon Province",
+      "North Chungcheong Province",
+      "South Chungcheong Province",
+      "North Jeolla Province",
+      "South Jeolla Province",
+      "North Gyeongsang Province",
+      "South Gyeongsang Province",
+      "Jeju"
+    ],
+    "country_code": "KR"
+  },
+  {
+    "country": "Kuwait",
+    "states": [
+      "Al Ahmadi",
+      "Al Farwaniyah",
+      "Al Asimah",
+      "Al Jahra",
+      "Hawalli",
+      "Mubarak Al-Kabeer"
+    ],
+    "country_code": "KW"
+  },
+  {
+    "country": "Kyrgyzstan",
+    "states": [
+      "Batken Oblasty",
+      "Bishkek Shaary",
+      "Chuy Oblasty",
+      "Jalal-Abad Oblasty",
+      "Naryn Oblasty",
+      "Osh Oblasty",
+      "Talas Oblasty",
+      "Ysyk-Kol Oblasty"
+    ],
+    "country_code": "KG"
+  },
+  {
+    "country": "Laos",
+    "states": [
+      "Attapu",
+      "Bokeo",
+      "Bolikhamxai",
+      "Champasak",
+      "Houaphan",
+      "Khammouan",
+      "Louangnamtha",
+      "Louangphrabang",
+      "Oudomxai",
+      "Phongsali",
+      "Salavan",
+      "Savannakhet",
+      "Viangchan",
+      "Viangchan",
+      "Xaignabouli",
+      "Xaisomboun",
+      "Xekong",
+      "Xiangkhoang"
+    ],
+    "country_code": "LA"
+  },
+  {
+    "country": "Latvia",
+    "states": [
+      "Aizkraukles Rajons",
+      "Aluksnes Rajons",
+      "Balvu Rajons",
+      "Bauskas Rajons",
+      "Cesu Rajons",
+      "Daugavpils",
+      "Daugavpils Rajons",
+      "Dobeles Rajons",
+      "Gulbenes Rajons",
+      "Jekabpils Rajons",
+      "Jelgava",
+      "Jelgavas Rajons",
+      "Jurmala",
+      "Kraslavas Rajons",
+      "Kuldigas Rajons",
+      "Liepaja",
+      "Liepajas Rajons",
+      "Limbazu Rajons",
+      "Ludzas Rajons",
+      "Madonas Rajons",
+      "Ogres Rajons",
+      "Preilu Rajons",
+      "Rezekne",
+      "Rezeknes Rajons",
+      "Riga",
+      "Rigas Rajons",
+      "Saldus Rajons",
+      "Talsu Rajons",
+      "Tukuma Rajons",
+      "Valkas Rajons",
+      "Valmieras Rajons",
+      "Ventspils",
+      "Ventspils Rajons"
+    ],
+    "country_code": "LV"
+  },
+  {
+    "country": "Lebanon",
+    "states": [
+      "Beyrouth",
+      "Beqaa",
+      "Liban-Nord",
+      "Liban-Sud",
+      "Mont-Liban",
+      "Nabatiye"
+    ],
+    "country_code": "LB"
+  },
+  {
+    "country": "Lesotho",
+    "states": [
+      "Berea",
+      "Butha-Buthe",
+      "Leribe",
+      "Mafeteng",
+      "Maseru",
+      "Mohale's Hoek",
+      "Mokhotlong",
+      "Qacha's Nek",
+      "Quthing",
+      "Thaba-Tseka"
+    ],
+    "country_code": "LS"
+  },
+  {
+    "country": "Liberia",
+    "states": [
+      "Bomi",
+      "Bong",
+      "Gbarpolu",
+      "Grand Bassa",
+      "Grand Cape Mount",
+      "Grand Gedeh",
+      "Grand Kru",
+      "Lofa",
+      "Margibi",
+      "Maryland",
+      "Montserrado",
+      "Nimba",
+      "River Cess",
+      "River Gee",
+      "Sinoe"
+    ],
+    "country_code": "LR"
+  },
+  {
+    "country": "Libya",
+    "states": [
+      "Ajdabiya",
+      "Al 'Aziziyah",
+      "Al Fatih",
+      "Al Jabal al Akhdar",
+      "Al Jufrah",
+      "Al Khums",
+      "Al Kufrah",
+      "An Nuqat al Khams",
+      "Ash Shati'",
+      "Awbari",
+      "Az Zawiyah",
+      "Banghazi",
+      "Darnah",
+      "Ghadamis",
+      "Gharyan",
+      "Misratah",
+      "Murzuq",
+      "Sabha",
+      "Sawfajjin",
+      "Surt",
+      "Tarabulus",
+      "Tarhunah",
+      "Tubruq",
+      "Yafran",
+      "Zlitan"
+    ],
+    "country_code": "LY"
+  },
+  {
+    "country": "Liechtenstein",
+    "states": [
+      "Balzers",
+      "Eschen",
+      "Gamprin",
+      "Mauren",
+      "Planken",
+      "Ruggell",
+      "Schaan",
+      "Schellenberg",
+      "Triesen",
+      "Triesenberg",
+      "Vaduz"
+    ],
+    "country_code": "LI"
+  },
+  {
+    "country": "Lithuania",
+    "states": [
+      "Alytaus",
+      "Kauno",
+      "Klaipedos",
+      "Marijampoles",
+      "Panevezio",
+      "Siauliu",
+      "Taurages",
+      "Telsiu",
+      "Utenos",
+      "Vilniaus"
+    ],
+    "country_code": "LT"
+  },
+  {
+    "country": "Luxembourg",
+    "states": [
+      "Diekirch",
+      "Grevenmacher",
+      "Luxembourg"
+    ],
+    "country_code": "LU"
+  },
+  {
+    "country": "Macedonia",
+    "states": [
+      "Aerodrom",
+      "Aracinovo",
+      "Berovo",
+      "Bitola",
+      "Bogdanci",
+      "Bogovinje",
+      "Bosilovo",
+      "Brvenica",
+      "Butel",
+      "Cair",
+      "Caska",
+      "Centar",
+      "Centar Zupa",
+      "Cesinovo",
+      "Cucer-Sandevo",
+      "Debar",
+      "Debartsa",
+      "Delcevo",
+      "Demir Hisar",
+      "Demir Kapija",
+      "Dojran",
+      "Dolneni",
+      "Drugovo",
+      "Gazi Baba",
+      "Gevgelija",
+      "Gjorce Petrov",
+      "Gostivar",
+      "Gradsko",
+      "Ilinden",
+      "Jegunovce",
+      "Karbinci",
+      "Karpos",
+      "Kavadarci",
+      "Kicevo",
+      "Kisela Voda",
+      "Kocani",
+      "Konce",
+      "Kratovo",
+      "Kriva Palanka",
+      "Krivogastani",
+      "Krusevo",
+      "Kumanovo",
+      "Lipkovo",
+      "Lozovo",
+      "Makedonska Kamenica",
+      "Makedonski Brod",
+      "Mavrovo i Rastusa",
+      "Mogila",
+      "Negotino",
+      "Novaci",
+      "Novo Selo",
+      "Ohrid",
+      "Oslomej",
+      "Pehcevo",
+      "Petrovec",
+      "Plasnica",
+      "Prilep",
+      "Probistip",
+      "Radovis",
+      "Rankovce",
+      "Resen",
+      "Rosoman",
+      "Saraj",
+      "Skopje",
+      "Sopiste",
+      "Staro Nagoricane",
+      "Stip",
+      "Struga",
+      "Strumica",
+      "Studenicani",
+      "Suto Orizari",
+      "Sveti Nikole",
+      "Tearce",
+      "Tetovo",
+      "Valandovo",
+      "Vasilevo",
+      "Veles",
+      "Vevcani",
+      "Vinica",
+      "Vranestica",
+      "Vrapciste",
+      "Zajas",
+      "Zelenikovo",
+      "Zelino",
+      "Zrnovci"
+    ],
+    "country_code": "MK"
+  },
+  {
+    "country": "Madagascar",
+    "states": [
+      "Antananarivo",
+      "Antsiranana",
+      "Fianarantsoa",
+      "Mahajanga",
+      "Toamasina",
+      "Toliara"
+    ],
+    "country_code": "MG"
+  },
+  {
+    "country": "Malawi",
+    "states": [
+      "Balaka",
+      "Blantyre",
+      "Chikwawa",
+      "Chiradzulu",
+      "Chitipa",
+      "Dedza",
+      "Dowa",
+      "Karonga",
+      "Kasungu",
+      "Likoma",
+      "Lilongwe",
+      "Machinga",
+      "Mangochi",
+      "Mchinji",
+      "Mulanje",
+      "Mwanza",
+      "Mzimba",
+      "Ntcheu",
+      "Nkhata Bay",
+      "Nkhotakota",
+      "Nsanje",
+      "Ntchisi",
+      "Phalombe",
+      "Rumphi",
+      "Salima",
+      "Thyolo",
+      "Zomba"
+    ],
+    "country_code": "MW"
+  },
+  {
+    "country": "Malaysia",
+    "states": [
+      "Johor",
+      "Kedah",
+      "Kelantan",
+      "Kuala Lumpur",
+      "Labuan",
+      "Malacca",
+      "Negeri Sembilan",
+      "Pahang",
+      "Perak",
+      "Perlis",
+      "Penang",
+      "Sabah",
+      "Sarawak",
+      "Selangor",
+      "Terengganu"
+    ],
+    "country_code": "MY"
+  },
+  {
+    "country": "Maldives",
+    "states": [
+      "Alifu",
+      "Baa",
+      "Dhaalu",
+      "Faafu",
+      "Gaafu Alifu",
+      "Gaafu Dhaalu",
+      "Gnaviyani",
+      "Haa Alifu",
+      "Haa Dhaalu",
+      "Kaafu",
+      "Laamu",
+      "Lhaviyani",
+      "Maale",
+      "Meemu",
+      "Noonu",
+      "Raa",
+      "Seenu",
+      "Shaviyani",
+      "Thaa",
+      "Vaavu"
+    ],
+    "country_code": "MV"
+  },
+  {
+    "country": "Mali",
+    "states": [
+      "Bamako (Capital)",
+      "Gao",
+      "Kayes",
+      "Kidal",
+      "Koulikoro",
+      "Mopti",
+      "Segou",
+      "Sikasso",
+      "Tombouctou"
+    ],
+    "country_code": "ML"
+  },
+  {
+    "country": "Malta",
+    "states": [],
+    "country_code": "MT"
+  },
+  {
+    "country": "Marshall Islands",
+    "states": [],
+    "country_code": "MH"
+  },
+  {
+    "country": "Mauritania",
+    "states": [
+      "Adrar",
+      "Assaba",
+      "Brakna",
+      "Dakhlet Nouadhibou",
+      "Gorgol",
+      "Guidimaka",
+      "Hodh Ech Chargui",
+      "Hodh El Gharbi",
+      "Inchiri",
+      "Nouakchott",
+      "Tagant",
+      "Tiris Zemmour",
+      "Trarza"
+    ],
+    "country_code": "MR"
+  },
+  {
+    "country": "Mauritius",
+    "states": [
+      "Agalega Islands",
+      "Black River",
+      "Cargados Carajos Shoals",
+      "Flacq",
+      "Grand Port",
+      "Moka",
+      "Pamplemousses",
+      "Plaines Wilhems",
+      "Port Louis",
+      "Riviere du Rempart",
+      "Rodrigues",
+      "Savanne"
+    ],
+    "country_code": "MU"
+  },
+  {
+    "country": "Micronesia",
+    "states": [],
+    "country_code": "FM"
+  },
+  {
+    "country": "Moldova",
+    "states": [
+      "Anenii Noi",
+      "Basarabeasca",
+      "Briceni",
+      "Cahul",
+      "Cantemir",
+      "Calarasi",
+      "Causeni",
+      "Cimislia",
+      "Criuleni",
+      "Donduseni",
+      "Drochia",
+      "Dubasari",
+      "Edinet",
+      "Falesti",
+      "Floresti",
+      "Glodeni",
+      "Hincesti",
+      "Ialoveni",
+      "Leova",
+      "Nisporeni",
+      "Ocnita",
+      "Orhei",
+      "Rezina",
+      "Riscani",
+      "Singerei",
+      "Soldanesti",
+      "Soroca",
+      "Stefan-Voda",
+      "Straseni",
+      "Taraclia",
+      "Telenesti",
+      "Ungheni",
+      "Balti",
+      "Bender",
+      "Chisinau",
+      "Gagauzia",
+      "Stinga Nistrului"
+    ],
+    "country_code": "MD"
+  },
+  {
+    "country": "Mongolia",
+    "states": [
+      "Arhangay",
+      "Bayanhongor",
+      "Bayan-Olgiy",
+      "Bulgan",
+      "Darhan Uul",
+      "Dornod",
+      "Dornogovi",
+      "Dundgovi",
+      "Dzavhan",
+      "Govi-Altay",
+      "Govi-Sumber",
+      "Hentiy",
+      "Hovd",
+      "Hovsgol",
+      "Omnogovi",
+      "Orhon",
+      "Ovorhangay",
+      "Selenge",
+      "Suhbaatar",
+      "Tov",
+      "Ulaanbaatar",
+      "Uvs"
+    ],
+    "country_code": "MN"
+  },
+  {
+    "country": "Montenegro",
+    "states": [],
+    "country_code": "ME"
+  },
+  {
+    "country": "Morocco",
+    "states": [
+      "Agadir",
+      "Al Hoceima",
+      "Azilal",
+      "Beni Mellal",
+      "Ben Slimane",
+      "Boulemane",
+      "Casablanca",
+      "Chaouen",
+      "El Jadida",
+      "El Kelaa des Sraghna",
+      "Er Rachidia",
+      "Essaouira",
+      "Fes",
+      "Figuig",
+      "Guelmim",
+      "Ifrane",
+      "Kenitra",
+      "Khemisset",
+      "Khenifra",
+      "Khouribga",
+      "Laayoune",
+      "Larache",
+      "Marrakech",
+      "Meknes",
+      "Nador",
+      "Ouarzazate",
+      "Oujda",
+      "Rabat-Sale",
+      "Safi",
+      "Settat",
+      "Sidi Kacem",
+      "Tangier",
+      "Tan-Tan",
+      "Taounate",
+      "Taroudannt",
+      "Tata",
+      "Taza",
+      "Tetouan",
+      "Tiznit"
+    ],
+    "country_code": "MA"
+  },
+  {
+    "country": "Monaco",
+    "states": [],
+    "country_code": "MC"
+  },
+  {
+    "country": "Mozambique",
+    "states": [
+      "Cabo Delgado",
+      "Gaza",
+      "Inhambane",
+      "Manica",
+      "Maputo",
+      "Cidade de Maputo",
+      "Nampula",
+      "Niassa",
+      "Sofala",
+      "Tete",
+      "Zambezia"
+    ],
+    "country_code": "MZ"
+  },
+  {
+    "country": "Namibia",
+    "states": [
+      "Caprivi",
+      "Erongo",
+      "Hardap",
+      "Karas",
+      "Khomas",
+      "Kunene",
+      "Ohangwena",
+      "Okavango",
+      "Omaheke",
+      "Omusati",
+      "Oshana",
+      "Oshikoto",
+      "Otjozondjupa"
+    ],
+    "country_code": "NA"
+  },
+  {
+    "country": "Nauru",
+    "states": [],
+    "country_code": "NR"
+  },
+  {
+    "country": "Nepal",
+    "states": [
+      "Bagmati",
+      "Bheri",
+      "Dhawalagiri",
+      "Gandaki",
+      "Janakpur",
+      "Karnali",
+      "Kosi",
+      "Lumbini",
+      "Mahakali",
+      "Mechi",
+      "Narayani",
+      "Rapti",
+      "Sagarmatha",
+      "Seti"
+    ],
+    "country_code": "NP"
+  },
+  {
+    "country": "Netherlands",
+    "states": [
+      "Drenthe",
+      "Flevoland",
+      "Friesland",
+      "Gelderland",
+      "Groningen",
+      "Limburg",
+      "Noord-Brabant",
+      "Noord-Holland",
+      "Overijssel",
+      "Utrecht",
+      "Zeeland",
+      "Zuid-Holland"
+    ],
+    "country_code": "NL"
+  },
+  {
+    "country": "New Zealand",
+    "states": [
+      "Auckland",
+      "Bay of Plenty",
+      "Canterbury",
+      "Chatham Islands",
+      "Gisborne",
+      "Hawke's Bay",
+      "Manawatu-Wanganui",
+      "Marlborough",
+      "Nelson",
+      "Northland",
+      "Otago",
+      "Southland",
+      "Taranaki",
+      "Tasman",
+      "Waikato",
+      "Wellington",
+      "West Coast"
+    ],
+    "country_code": "NZ"
+  },
+  {
+    "country": "Nicaragua",
+    "states": [
+      "Atlantico Norte",
+      "Atlantico Sur",
+      "Boaco",
+      "Carazo",
+      "Chinandega",
+      "Chontales",
+      "Esteli",
+      "Granada",
+      "Jinotega",
+      "Leon",
+      "Madriz",
+      "Managua",
+      "Masaya",
+      "Matagalpa",
+      "Nueva Segovia",
+      "Rio San Juan",
+      "Rivas"
+    ],
+    "country_code": "NI"
+  },
+  {
+    "country": "Niger",
+    "states": [
+      "Agadez",
+      "Diffa",
+      "Dosso",
+      "Maradi",
+      "Niamey",
+      "Tahoua",
+      "Tillaberi",
+      "Zinder"
+    ],
+    "country_code": "NE"
+  },
+  {
+    "country": "Nigeria",
+    "states": [
+      "Abia",
+      "Abuja Federal Capital",
+      "Adamawa",
+      "Akwa Ibom",
+      "Anambra",
+      "Bauchi",
+      "Bayelsa",
+      "Benue",
+      "Borno",
+      "Cross River",
+      "Delta",
+      "Ebonyi",
+      "Edo",
+      "Ekiti",
+      "Enugu",
+      "Gombe",
+      "Imo",
+      "Jigawa",
+      "Kaduna",
+      "Kano",
+      "Katsina",
+      "Kebbi",
+      "Kogi",
+      "Kwara",
+      "Lagos",
+      "Nassarawa",
+      "Niger",
+      "Ogun",
+      "Ondo",
+      "Osun",
+      "Oyo",
+      "Plateau",
+      "Rivers",
+      "Sokoto",
+      "Taraba",
+      "Yobe",
+      "Zamfara"
+    ],
+    "country_code": "NG"
+  },
+  {
+    "country": "Norway",
+    "states": [
+      "Akershus",
+      "Aust-Agder",
+      "Buskerud",
+      "Finnmark",
+      "Hedmark",
+      "Hordaland",
+      "More og Romsdal",
+      "Nordland",
+      "Nord-Trondelag",
+      "Oppland",
+      "Oslo",
+      "Ostfold",
+      "Rogaland",
+      "Sogn og Fjordane",
+      "Sor-Trondelag",
+      "Telemark",
+      "Troms",
+      "Vest-Agder",
+      "Vestfold"
+    ],
+    "country_code": "NO"
+  },
+  {
+    "country": "Oman",
+    "states": [
+      "Ad Dakhiliyah",
+      "Al Batinah",
+      "Al Wusta",
+      "Ash Sharqiyah",
+      "Az Zahirah",
+      "Masqat",
+      "Musandam",
+      "Dhofar"
+    ],
+    "country_code": "OM"
+  },
+  {
+    "country": "Pakistan",
+    "states": [
+      "Balochistan",
+      "North-West Frontier Province",
+      "Punjab",
+      "Sindh",
+      "Islamabad Capital Territory",
+      "Federally Administered Tribal Areas"
+    ],
+    "country_code": "PK"
+  },
+  {
+    "country": "Panama",
+    "states": [
+      "Bocas del Toro",
+      "Chiriqui",
+      "Cocle",
+      "Colon",
+      "Darien",
+      "Herrera",
+      "Los Santos",
+      "Panama",
+      "San Blas",
+      "Veraguas"
+    ],
+    "country_code": "PA"
+  },
+  {
+    "country": "Papua New Guinea",
+    "states": [
+      "Bougainville",
+      "Central",
+      "Chimbu",
+      "Eastern Highlands",
+      "East New Britain",
+      "East Sepik",
+      "Enga",
+      "Gulf",
+      "Madang",
+      "Manus",
+      "Milne Bay",
+      "Morobe",
+      "National Capital",
+      "New Ireland",
+      "Northern",
+      "Sandaun",
+      "Southern Highlands",
+      "Western",
+      "Western Highlands",
+      "West New Britain"
+    ],
+    "country_code": "PG"
+  },
+  {
+    "country": "Paraguay",
+    "states": [
+      "Alto Paraguay",
+      "Alto Parana",
+      "Amambay",
+      "Asuncion",
+      "Boqueron",
+      "Caaguazu",
+      "Caazapa",
+      "Canindeyu",
+      "Central",
+      "Concepcion",
+      "Cordillera",
+      "Guaira",
+      "Itapua",
+      "Misiones",
+      "Neembucu",
+      "Paraguari",
+      "Presidente Hayes",
+      "San Pedro"
+    ],
+    "country_code": "PY"
+  },
+  {
+    "country": "Peru",
+    "states": [
+      "Amazonas",
+      "Ancash",
+      "Apurimac",
+      "Arequipa",
+      "Ayacucho",
+      "Cajamarca",
+      "Callao",
+      "Cusco",
+      "Huancavelica",
+      "Huanuco",
+      "Ica",
+      "Junin",
+      "La Libertad",
+      "Lambayeque",
+      "Lima",
+      "Loreto",
+      "Madre de Dios",
+      "Moquegua",
+      "Pasco",
+      "Piura",
+      "Puno",
+      "San Martin",
+      "Tacna",
+      "Tumbes",
+      "Ucayali"
+    ],
+    "country_code": "PE"
+  },
+  {
+    "country": "Philippines",
+    "states": [
+      "Abra",
+      "Agusan del Norte",
+      "Agusan del Sur",
+      "Aklan",
+      "Albay",
+      "Antique",
+      "Apayao",
+      "Aurora",
+      "Basilan",
+      "Bataan",
+      "Batanes",
+      "Batangas",
+      "Biliran",
+      "Benguet",
+      "Bohol",
+      "Bukidnon",
+      "Bulacan",
+      "Cagayan",
+      "Camarines Norte",
+      "Camarines Sur",
+      "Camiguin",
+      "Capiz",
+      "Catanduanes",
+      "Cavite",
+      "Cebu",
+      "Compostela",
+      "Davao del Norte",
+      "Davao del Sur",
+      "Davao Oriental",
+      "Eastern Samar",
+      "Guimaras",
+      "Ifugao",
+      "Ilocos Norte",
+      "Ilocos Sur",
+      "Iloilo",
+      "Isabela",
+      "Kalinga",
+      "Laguna",
+      "Lanao del Norte",
+      "Lanao del Sur",
+      "La Union",
+      "Leyte",
+      "Maguindanao",
+      "Marinduque",
+      "Masbate",
+      "Mindoro Occidental",
+      "Mindoro Oriental",
+      "Misamis Occidental",
+      "Misamis Oriental",
+      "Mountain Province",
+      "Negros Occidental",
+      "Negros Oriental",
+      "North Cotabato",
+      "Northern Samar",
+      "Nueva Ecija",
+      "Nueva Vizcaya",
+      "Palawan",
+      "Pampanga",
+      "Pangasinan",
+      "Quezon",
+      "Quirino",
+      "Rizal",
+      "Romblon",
+      "Samar",
+      "Sarangani",
+      "Siquijor",
+      "Sorsogon",
+      "South Cotabato",
+      "Southern Leyte",
+      "Sultan Kudarat",
+      "Sulu",
+      "Surigao del Norte",
+      "Surigao del Sur",
+      "Tarlac",
+      "Tawi-Tawi",
+      "Zambales",
+      "Zamboanga del Norte",
+      "Zamboanga del Sur",
+      "Zamboanga Sibugay"
+    ],
+    "country_code": "PH"
+  },
+  {
+    "country": "Poland",
+    "states": [
+      "Greater Poland (Wielkopolskie)",
+      "Kuyavian-Pomeranian (Kujawsko-Pomorskie)",
+      "Lesser Poland (Malopolskie)",
+      "Lodz (Lodzkie)",
+      "Lower Silesian (Dolnoslaskie)",
+      "Lublin (Lubelskie)",
+      "Lubusz (Lubuskie)",
+      "Masovian (Mazowieckie)",
+      "Opole (Opolskie)",
+      "Podlasie (Podlaskie)",
+      "Pomeranian (Pomorskie)",
+      "Silesian (Slaskie)",
+      "Subcarpathian (Podkarpackie)",
+      "Swietokrzyskie (Swietokrzyskie)",
+      "Warmian-Masurian (Warminsko-Mazurskie)",
+      "West Pomeranian (Zachodniopomorskie)"
+    ],
+    "country_code": "PL"
+  },
+  {
+    "country": "Portugal",
+    "states": [
+      "Aveiro",
+      "Acores",
+      "Beja",
+      "Braga",
+      "Braganca",
+      "Castelo Branco",
+      "Coimbra",
+      "Evora",
+      "Faro",
+      "Guarda",
+      "Leiria",
+      "Lisboa",
+      "Madeira",
+      "Portalegre",
+      "Porto",
+      "Santarem",
+      "Setubal",
+      "Viana do Castelo",
+      "Vila Real",
+      "Viseu"
+    ],
+    "country_code": "PT"
+  },
+  {
+    "country": "Qatar",
+    "states": [
+      "Ad Dawhah",
+      "Al Ghuwayriyah",
+      "Al Jumayliyah",
+      "Al Khawr",
+      "Al Wakrah",
+      "Ar Rayyan",
+      "Jarayan al Batinah",
+      "Madinat ash Shamal",
+      "Umm Sa'id",
+      "Umm Salal"
+    ],
+    "country_code": "QA"
+  },
+  {
+    "country": "Romania",
+    "states": [
+      "Alba",
+      "Arad",
+      "Arges",
+      "Bacau",
+      "Bihor",
+      "Bistrita-Nasaud",
+      "Botosani",
+      "Braila",
+      "Brasov",
+      "Bucuresti",
+      "Buzau",
+      "Calarasi",
+      "Caras-Severin",
+      "Cluj",
+      "Constanta",
+      "Covasna",
+      "Dimbovita",
+      "Dolj",
+      "Galati",
+      "Gorj",
+      "Giurgiu",
+      "Harghita",
+      "Hunedoara",
+      "Ialomita",
+      "Iasi",
+      "Ilfov",
+      "Maramures",
+      "Mehedinti",
+      "Mures",
+      "Neamt",
+      "Olt",
+      "Prahova",
+      "Salaj",
+      "Satu Mare",
+      "Sibiu",
+      "Suceava",
+      "Teleorman",
+      "Timis",
+      "Tulcea",
+      "Vaslui",
+      "Vilcea",
+      "Vrancea"
+    ],
+    "country_code": "RO"
+  },
+  {
+    "country": "Russia",
+    "states": [
+      "Amur",
+      "Arkhangel'sk",
+      "Astrakhan'",
+      "Belgorod",
+      "Bryansk",
+      "Chelyabinsk",
+      "Chita",
+      "Irkutsk",
+      "Ivanovo",
+      "Kaliningrad",
+      "Kaluga",
+      "Kamchatka",
+      "Kemerovo",
+      "Kirov",
+      "Kostroma",
+      "Kurgan",
+      "Kursk",
+      "Leningrad",
+      "Lipetsk",
+      "Magadan",
+      "Moscow",
+      "Murmansk",
+      "Nizhniy Novgorod",
+      "Novgorod",
+      "Novosibirsk",
+      "Omsk",
+      "Orenburg",
+      "Orel",
+      "Penza",
+      "Perm'",
+      "Pskov",
+      "Rostov",
+      "Ryazan'",
+      "Sakhalin",
+      "Samara",
+      "Saratov",
+      "Smolensk",
+      "Sverdlovsk",
+      "Tambov",
+      "Tomsk",
+      "Tula",
+      "Tver'",
+      "Tyumen'",
+      "Ul'yanovsk",
+      "Vladimir",
+      "Volgograd",
+      "Vologda",
+      "Voronezh",
+      "Yaroslavl'",
+      "Adygeya",
+      "Altay",
+      "Bashkortostan",
+      "Buryatiya",
+      "Chechnya",
+      "Chuvashiya",
+      "Dagestan",
+      "Ingushetiya",
+      "Kabardino-Balkariya",
+      "Kalmykiya",
+      "Karachayevo-Cherkesiya",
+      "Kareliya",
+      "Khakasiya",
+      "Komi",
+      "Mariy-El",
+      "Mordoviya",
+      "Sakha",
+      "North Ossetia",
+      "Tatarstan",
+      "Tyva",
+      "Udmurtiya",
+      "Aga Buryat",
+      "Chukotka",
+      "Evenk",
+      "Khanty-Mansi",
+      "Komi-Permyak",
+      "Koryak",
+      "Nenets",
+      "Taymyr",
+      "Ust'-Orda Buryat",
+      "Yamalo-Nenets",
+      "Altay",
+      "Khabarovsk",
+      "Krasnodar",
+      "Krasnoyarsk",
+      "Primorskiy",
+      "Stavropol'",
+      "Moscow",
+      "St. Petersburg",
+      "Yevrey"
+    ],
+    "country_code": "RU"
+  },
+  {
+    "country": "Rwanda",
+    "states": [
+      "Butare",
+      "Byumba",
+      "Cyangugu",
+      "Gikongoro",
+      "Gisenyi",
+      "Gitarama",
+      "Kibungo",
+      "Kibuye",
+      "Kigali Rurale",
+      "Kigali-ville",
+      "Umutara",
+      "Ruhengeri"
+    ],
+    "country_code": "RW"
+  },
+  {
+    "country": "Samoa",
+    "states": [
+      "A'ana",
+      "Aiga-i-le-Tai",
+      "Atua",
+      "Fa'asaleleaga",
+      "Gaga'emauga",
+      "Gagaifomauga",
+      "Palauli",
+      "Satupa'itea",
+      "Tuamasaga",
+      "Va'a-o-Fonoti",
+      "Vaisigano"
+    ],
+    "country_code": "WS"
+  },
+  {
+    "country": "San Marino",
+    "states": [
+      "Acquaviva",
+      "Borgo Maggiore",
+      "Chiesanuova",
+      "Domagnano",
+      "Faetano",
+      "Fiorentino",
+      "Montegiardino",
+      "San Marino Citta",
+      "Serravalle"
+    ],
+    "country_code": "SM"
+  },
+  {
+    "country": "Sao Tome",
+    "states": [],
+    "country_code": "ST"
+  },
+  {
+    "country": "Saudi Arabia",
+    "states": [
+      "Al Bahah",
+      "Al Hudud ash Shamaliyah",
+      "Al Jawf",
+      "Al Madinah",
+      "Al Qasim",
+      "Ar Riyad",
+      "Ash Sharqiyah",
+      "'Asir",
+      "Ha'il",
+      "Jizan",
+      "Makkah",
+      "Najran",
+      "Tabuk"
+    ],
+    "country_code": "SA"
+  },
+  {
+    "country": "Senegal",
+    "states": [
+      "Dakar",
+      "Diourbel",
+      "Fatick",
+      "Kaolack",
+      "Kolda",
+      "Louga",
+      "Matam",
+      "Saint-Louis",
+      "Tambacounda",
+      "Thies",
+      "Ziguinchor"
+    ],
+    "country_code": "SN"
+  },
+  {
+    "country": "Serbia",
+    "states": [
+      "Kosovo",
+      "Montenegro",
+      "Serbia",
+      "Vojvodina"
+    ],
+    "country_code": "RS"
+  },
+  {
+    "country": "Seychelles",
+    "states": [
+      "Anse aux Pins",
+      "Anse Boileau",
+      "Anse Etoile",
+      "Anse Louis",
+      "Anse Royale",
+      "Baie Lazare",
+      "Baie Sainte Anne",
+      "Beau Vallon",
+      "Bel Air",
+      "Bel Ombre",
+      "Cascade",
+      "Glacis",
+      "Grand' Anse",
+      "Grand' Anse",
+      "La Digue",
+      "La Riviere Anglaise",
+      "Mont Buxton",
+      "Mont Fleuri",
+      "Plaisance",
+      "Pointe La Rue",
+      "Port Glaud",
+      "Saint Louis",
+      "Takamaka"
+    ],
+    "country_code": "SC"
+  },
+  {
+    "country": "Sierra Leone",
+    "states": [],
+    "country_code": "SL"
+  },
+  {
+    "country": "Singapore",
+    "states": [],
+    "country_code": "SG"
+  },
+  {
+    "country": "Slovakia",
+    "states": [
+      "Banskobystricky",
+      "Bratislavsky",
+      "Kosicky",
+      "Nitriansky",
+      "Presovsky",
+      "Trenciansky",
+      "Trnavsky",
+      "Zilinsky"
+    ],
+    "country_code": "SK"
+  },
+  {
+    "country": "Slovenia",
+    "states": [
+      "Ajdovscina",
+      "Beltinci",
+      "Benedikt",
+      "Bistrica ob Sotli",
+      "Bled",
+      "Bloke",
+      "Bohinj",
+      "Borovnica",
+      "Bovec",
+      "Braslovce",
+      "Brda",
+      "Brezice",
+      "Brezovica",
+      "Cankova",
+      "Celje",
+      "Cerklje na Gorenjskem",
+      "Cerknica",
+      "Cerkno",
+      "Cerkvenjak",
+      "Crensovci",
+      "Crna na Koroskem",
+      "Crnomelj",
+      "Destrnik",
+      "Divaca",
+      "Dobje",
+      "Dobrepolje",
+      "Dobrna",
+      "Dobrova-Horjul-Polhov Gradec",
+      "Dobrovnik-Dobronak",
+      "Dolenjske Toplice",
+      "Dol pri Ljubljani",
+      "Domzale",
+      "Dornava",
+      "Dravograd",
+      "Duplek",
+      "Gorenja Vas-Poljane",
+      "Gorisnica",
+      "Gornja Radgona",
+      "Gornji Grad",
+      "Gornji Petrovci",
+      "Grad",
+      "Grosuplje",
+      "Hajdina",
+      "Hoce-Slivnica",
+      "Hodos-Hodos",
+      "Horjul",
+      "Hrastnik",
+      "Hrpelje-Kozina",
+      "Idrija",
+      "Ig",
+      "Ilirska Bistrica",
+      "Ivancna Gorica",
+      "Izola-Isola",
+      "Jesenice",
+      "Jezersko",
+      "Jursinci",
+      "Kamnik",
+      "Kanal",
+      "Kidricevo",
+      "Kobarid",
+      "Kobilje",
+      "Kocevje",
+      "Komen",
+      "Komenda",
+      "Koper-Capodistria",
+      "Kostel",
+      "Kozje",
+      "Kranj",
+      "Kranjska Gora",
+      "Krizevci",
+      "Krsko",
+      "Kungota",
+      "Kuzma",
+      "Lasko",
+      "Lenart",
+      "Lendava-Lendva",
+      "Litija",
+      "Ljubljana",
+      "Ljubno",
+      "Ljutomer",
+      "Logatec",
+      "Loska Dolina",
+      "Loski Potok",
+      "Lovrenc na Pohorju",
+      "Luce",
+      "Lukovica",
+      "Majsperk",
+      "Maribor",
+      "Markovci",
+      "Medvode",
+      "Menges",
+      "Metlika",
+      "Mezica",
+      "Miklavz na Dravskem Polju",
+      "Miren-Kostanjevica",
+      "Mirna Pec",
+      "Mislinja",
+      "Moravce",
+      "Moravske Toplice",
+      "Mozirje",
+      "Murska Sobota",
+      "Muta",
+      "Naklo",
+      "Nazarje",
+      "Nova Gorica",
+      "Novo Mesto",
+      "Odranci",
+      "Oplotnica",
+      "Ormoz",
+      "Osilnica",
+      "Pesnica",
+      "Piran-Pirano",
+      "Pivka",
+      "Podcetrtek",
+      "Podlehnik",
+      "Podvelka",
+      "Polzela",
+      "Postojna",
+      "Prebold",
+      "Preddvor",
+      "Prevalje",
+      "Ptuj",
+      "Puconci",
+      "Race-Fram",
+      "Radece",
+      "Radenci",
+      "Radlje ob Dravi",
+      "Radovljica",
+      "Ravne na Koroskem",
+      "Razkrizje",
+      "Ribnica",
+      "Ribnica na Pohorju",
+      "Rogasovci",
+      "Rogaska Slatina",
+      "Rogatec",
+      "Ruse",
+      "Salovci",
+      "Selnica ob Dravi",
+      "Semic",
+      "Sempeter-Vrtojba",
+      "Sencur",
+      "Sentilj",
+      "Sentjernej",
+      "Sentjur pri Celju",
+      "Sevnica",
+      "Sezana",
+      "Skocjan",
+      "Skofja Loka",
+      "Skofljica",
+      "Slovenj Gradec",
+      "Slovenska Bistrica",
+      "Slovenske Konjice",
+      "Smarje pri Jelsah",
+      "Smartno ob Paki",
+      "Smartno pri Litiji",
+      "Sodrazica",
+      "Solcava",
+      "Sostanj",
+      "Starse",
+      "Store",
+      "Sveta Ana",
+      "Sveti Andraz v Slovenskih Goricah",
+      "Sveti Jurij",
+      "Tabor",
+      "Tisina",
+      "Tolmin",
+      "Trbovlje",
+      "Trebnje",
+      "Trnovska Vas",
+      "Trzic",
+      "Trzin",
+      "Turnisce",
+      "Velenje",
+      "Velika Polana",
+      "Velike Lasce",
+      "Verzej",
+      "Videm",
+      "Vipava",
+      "Vitanje",
+      "Vodice",
+      "Vojnik",
+      "Vransko",
+      "Vrhnika",
+      "Vuzenica",
+      "Zagorje ob Savi",
+      "Zalec",
+      "Zavrc",
+      "Zelezniki",
+      "Zetale",
+      "Ziri",
+      "Zirovnica",
+      "Zuzemberk",
+      "Zrece"
+    ],
+    "country_code": "SI"
+  },
+  {
+    "country": "Solomon Islands",
+    "states": [
+      "Central",
+      "Choiseul",
+      "Guadalcanal",
+      "Honiara",
+      "Isabel",
+      "Makira",
+      "Malaita",
+      "Rennell and Bellona",
+      "Temotu",
+      "Western"
+    ],
+    "country_code": "SB"
+  },
+  {
+    "country": "Somalia",
+    "states": [
+      "Awdal",
+      "Bakool",
+      "Banaadir",
+      "Bari",
+      "Bay",
+      "Galguduud",
+      "Gedo",
+      "Hiiraan",
+      "Jubbada Dhexe",
+      "Jubbada Hoose",
+      "Mudug",
+      "Nugaal",
+      "Sanaag",
+      "Shabeellaha Dhexe",
+      "Shabeellaha Hoose",
+      "Sool",
+      "Togdheer",
+      "Woqooyi Galbeed"
+    ],
+    "country_code": "SO"
+  },
+  {
+    "country": "South Africa",
+    "states": [
+      "Eastern Cape",
+      "Free State",
+      "Gauteng",
+      "KwaZulu-Natal",
+      "Limpopo",
+      "Mpumalanga",
+      "North-West",
+      "Northern Cape",
+      "Western Cape"
+    ],
+    "country_code": "ZA"
+  },
+  {
+    "country": "Spain",
+    "states": [
+      "Andalucia",
+      "Aragon",
+      "Asturias",
+      "Baleares",
+      "Ceuta",
+      "Canarias",
+      "Cantabria",
+      "Castilla-La Mancha",
+      "Castilla y Leon",
+      "Cataluna",
+      "Comunidad Valenciana",
+      "Extremadura",
+      "Galicia",
+      "La Rioja",
+      "Madrid",
+      "Melilla",
+      "Murcia",
+      "Navarra",
+      "Pais Vasco"
+    ],
+    "country_code": "ES"
+  },
+  {
+    "country": "Sri Lanka",
+    "states": [
+      "Central",
+      "North Central",
+      "North Eastern",
+      "North Western",
+      "Sabaragamuwa",
+      "Southern",
+      "Uva",
+      "Western"
+    ],
+    "country_code": "LK"
+  },
+  {
+    "country": "Sudan",
+    "states": [
+      "A'ali an Nil",
+      "Al Bahr al Ahmar",
+      "Al Buhayrat",
+      "Al Jazirah",
+      "Al Khartum",
+      "Al Qadarif",
+      "Al Wahdah",
+      "An Nil al Abyad",
+      "An Nil al Azraq",
+      "Ash Shamaliyah",
+      "Bahr al Jabal",
+      "Gharb al Istiwa'iyah",
+      "Gharb Bahr al Ghazal",
+      "Gharb Darfur",
+      "Gharb Kurdufan",
+      "Janub Darfur",
+      "Janub Kurdufan",
+      "Junqali",
+      "Kassala",
+      "Nahr an Nil",
+      "Shamal Bahr al Ghazal",
+      "Shamal Darfur",
+      "Shamal Kurdufan",
+      "Sharq al Istiwa'iyah",
+      "Sinnar",
+      "Warab"
+    ],
+    "country_code": "SD"
+  },
+  {
+    "country": "Suriname",
+    "states": [
+      "Brokopondo",
+      "Commewijne",
+      "Coronie",
+      "Marowijne",
+      "Nickerie",
+      "Para",
+      "Paramaribo",
+      "Saramacca",
+      "Sipaliwini",
+      "Wanica"
+    ],
+    "country_code": "SR"
+  },
+  {
+    "country": "Swaziland",
+    "states": [
+      "Hhohho",
+      "Lubombo",
+      "Manzini",
+      "Shiselweni"
+    ],
+    "country_code": "SZ"
+  },
+  {
+    "country": "Sweden",
+    "states": [
+      "Blekinge",
+      "Dalarnas",
+      "Gavleborgs",
+      "Gotlands",
+      "Hallands",
+      "Jamtlands",
+      "Jonkopings",
+      "Kalmar",
+      "Kronobergs",
+      "Norrbottens",
+      "Orebro",
+      "Ostergotlands",
+      "Skane",
+      "Sodermanlands",
+      "Stockholms",
+      "Uppsala",
+      "Varmlands",
+      "Vasterbottens",
+      "Vasternorrlands",
+      "Vastmanlands",
+      "Vastra Gotalands"
+    ],
+    "country_code": "SE"
+  },
+  {
+    "country": "Switzerland",
+    "states": [
+      "Aargau",
+      "Appenzell Ausser-Rhoden",
+      "Appenzell Inner-Rhoden",
+      "Basel-Landschaft",
+      "Basel-Stadt",
+      "Bern",
+      "Fribourg",
+      "Geneve",
+      "Glarus",
+      "Graubunden",
+      "Jura",
+      "Luzern",
+      "Neuchatel",
+      "Nidwalden",
+      "Obwalden",
+      "Sankt Gallen",
+      "Schaffhausen",
+      "Schwyz",
+      "Solothurn",
+      "Thurgau",
+      "Ticino",
+      "Uri",
+      "Valais",
+      "Vaud",
+      "Zug",
+      "Zurich"
+    ],
+    "country_code": "CH"
+  },
+  {
+    "country": "Syria",
+    "states": [
+      "Al Hasakah",
+      "Al Ladhiqiyah",
+      "Al Qunaytirah",
+      "Ar Raqqah",
+      "As Suwayda'",
+      "Dar'a",
+      "Dayr az Zawr",
+      "Dimashq",
+      "Halab",
+      "Hamah",
+      "Hims",
+      "Idlib",
+      "Rif Dimashq",
+      "Tartus"
+    ],
+    "country_code": "SY"
+  },
+  {
+    "country": "Taiwan",
+    "states": [
+      "Chang-hua",
+      "Chia-i",
+      "Hsin-chu",
+      "Hua-lien",
+      "I-lan",
+      "Kao-hsiung",
+      "Kin-men",
+      "Lien-chiang",
+      "Miao-li",
+      "Nan-t'ou",
+      "P'eng-hu",
+      "P'ing-tung",
+      "T'ai-chung",
+      "T'ai-nan",
+      "T'ai-pei",
+      "T'ai-tung",
+      "T'ao-yuan",
+      "Yun-lin",
+      "Chia-i",
+      "Chi-lung",
+      "Hsin-chu",
+      "T'ai-chung",
+      "T'ai-nan",
+      "Kao-hsiung city",
+      "T'ai-pei city"
+    ],
+    "country_code": "TW"
+  },
+  {
+    "country": "Tajikistan",
+    "states": [],
+    "country_code": "TJ"
+  },
+  {
+    "country": "Tanzania",
+    "states": [
+      "Arusha",
+      "Dar es Salaam",
+      "Dodoma",
+      "Iringa",
+      "Kagera",
+      "Kigoma",
+      "Kilimanjaro",
+      "Lindi",
+      "Manyara",
+      "Mara",
+      "Mbeya",
+      "Morogoro",
+      "Mtwara",
+      "Mwanza",
+      "Pemba North",
+      "Pemba South",
+      "Pwani",
+      "Rukwa",
+      "Ruvuma",
+      "Shinyanga",
+      "Singida",
+      "Tabora",
+      "Tanga",
+      "Zanzibar Central/South",
+      "Zanzibar North",
+      "Zanzibar Urban/West"
+    ],
+    "country_code": "TZ"
+  },
+  {
+    "country": "Thailand",
+    "states": [
+      "Amnat Charoen",
+      "Ang Thong",
+      "Buriram",
+      "Chachoengsao",
+      "Chai Nat",
+      "Chaiyaphum",
+      "Chanthaburi",
+      "Chiang Mai",
+      "Chiang Rai",
+      "Chon Buri",
+      "Chumphon",
+      "Kalasin",
+      "Kamphaeng Phet",
+      "Kanchanaburi",
+      "Khon Kaen",
+      "Krabi",
+      "Krung Thep Mahanakhon",
+      "Lampang",
+      "Lamphun",
+      "Loei",
+      "Lop Buri",
+      "Mae Hong Son",
+      "Maha Sarakham",
+      "Mukdahan",
+      "Nakhon Nayok",
+      "Nakhon Pathom",
+      "Nakhon Phanom",
+      "Nakhon Ratchasima",
+      "Nakhon Sawan",
+      "Nakhon Si Thammarat",
+      "Nan",
+      "Narathiwat",
+      "Nong Bua Lamphu",
+      "Nong Khai",
+      "Nonthaburi",
+      "Pathum Thani",
+      "Pattani",
+      "Phangnga",
+      "Phatthalung",
+      "Phayao",
+      "Phetchabun",
+      "Phetchaburi",
+      "Phichit",
+      "Phitsanulok",
+      "Phra Nakhon Si Ayutthaya",
+      "Phrae",
+      "Phuket",
+      "Prachin Buri",
+      "Prachuap Khiri Khan",
+      "Ranong",
+      "Ratchaburi",
+      "Rayong",
+      "Roi Et",
+      "Sa Kaeo",
+      "Sakon Nakhon",
+      "Samut Prakan",
+      "Samut Sakhon",
+      "Samut Songkhram",
+      "Sara Buri",
+      "Satun",
+      "Sing Buri",
+      "Sisaket",
+      "Songkhla",
+      "Sukhothai",
+      "Suphan Buri",
+      "Surat Thani",
+      "Surin",
+      "Tak",
+      "Trang",
+      "Trat",
+      "Ubon Ratchathani",
+      "Udon Thani",
+      "Uthai Thani",
+      "Uttaradit",
+      "Yala",
+      "Yasothon"
+    ],
+    "country_code": "TH"
+  },
+  {
+    "country": "Togo",
+    "states": [
+      "Kara",
+      "Plateaux",
+      "Savanes",
+      "Centrale",
+      "Maritime"
+    ],
+    "country_code": "TG"
+  },
+  {
+    "country": "Tonga",
+    "states": [],
+    "country_code": "TO"
+  },
+  {
+    "country": "Trinidad and Tobago",
+    "states": [
+      "Couva",
+      "Diego Martin",
+      "Mayaro",
+      "Penal",
+      "Princes Town",
+      "Sangre Grande",
+      "San Juan",
+      "Siparia",
+      "Tunapuna",
+      "Port-of-Spain",
+      "San Fernando",
+      "Arima",
+      "Point Fortin",
+      "Chaguanas",
+      "Tobago"
+    ],
+    "country_code": "TT"
+  },
+  {
+    "country": "Tunisia",
+    "states": [
+      "Ariana (Aryanah)",
+      "Beja (Bajah)",
+      "Ben Arous (Bin 'Arus)",
+      "Bizerte (Banzart)",
+      "Gabes (Qabis)",
+      "Gafsa (Qafsah)",
+      "Jendouba (Jundubah)",
+      "Kairouan (Al Qayrawan)",
+      "Kasserine (Al Qasrayn)",
+      "Kebili (Qibili)",
+      "Kef (Al Kaf)",
+      "Mahdia (Al Mahdiyah)",
+      "Manouba (Manubah)",
+      "Medenine (Madanin)",
+      "Monastir (Al Munastir)",
+      "Nabeul (Nabul)",
+      "Sfax (Safaqis)",
+      "Sidi Bou Zid (Sidi Bu Zayd)",
+      "Siliana (Silyanah)",
+      "Sousse (Susah)",
+      "Tataouine (Tatawin)",
+      "Tozeur (Tawzar)",
+      "Tunis",
+      "Zaghouan (Zaghwan)"
+    ],
+    "country_code": "TN"
+  },
+  {
+    "country": "Turkey",
+    "states": [
+      "Adana",
+      "Adiyaman",
+      "Afyonkarahisar",
+      "Agri",
+      "Aksaray",
+      "Amasya",
+      "Ankara",
+      "Antalya",
+      "Ardahan",
+      "Artvin",
+      "Aydin",
+      "Balikesir",
+      "Bartin",
+      "Batman",
+      "Bayburt",
+      "Bilecik",
+      "Bingol",
+      "Bitlis",
+      "Bolu",
+      "Burdur",
+      "Bursa",
+      "Canakkale",
+      "Cankiri",
+      "Corum",
+      "Denizli",
+      "Diyarbakir",
+      "Duzce",
+      "Edirne",
+      "Elazig",
+      "Erzincan",
+      "Erzurum",
+      "Eskisehir",
+      "Gaziantep",
+      "Giresun",
+      "Gumushane",
+      "Hakkari",
+      "Hatay",
+      "Igdir",
+      "Isparta",
+      "Istanbul",
+      "Izmir",
+      "Kahramanmaras",
+      "Karabuk",
+      "Karaman",
+      "Kars",
+      "Kastamonu",
+      "Kayseri",
+      "Kilis",
+      "Kirikkale",
+      "Kirklareli",
+      "Kirsehir",
+      "Kocaeli",
+      "Konya",
+      "Kutahya",
+      "Malatya",
+      "Manisa",
+      "Mardin",
+      "Mersin",
+      "Mugla",
+      "Mus",
+      "Nevsehir",
+      "Nigde",
+      "Ordu",
+      "Osmaniye",
+      "Rize",
+      "Sakarya",
+      "Samsun",
+      "Sanliurfa",
+      "Siirt",
+      "Sinop",
+      "Sirnak",
+      "Sivas",
+      "Tekirdag",
+      "Tokat",
+      "Trabzon",
+      "Tunceli",
+      "Usak",
+      "Van",
+      "Yalova",
+      "Yozgat",
+      "Zonguldak"
+    ],
+    "country_code": "TR"
+  },
+  {
+    "country": "Turkmenistan",
+    "states": [
+      "Ahal Welayaty (Ashgabat)",
+      "Balkan Welayaty (Balkanabat)",
+      "Dashoguz Welayaty",
+      "Lebap Welayaty (Turkmenabat)",
+      "Mary Welayaty"
+    ],
+    "country_code": "TM"
+  },
+  {
+    "country": "Uganda",
+    "states": [
+      "Adjumani",
+      "Apac",
+      "Arua",
+      "Bugiri",
+      "Bundibugyo",
+      "Bushenyi",
+      "Busia",
+      "Gulu",
+      "Hoima",
+      "Iganga",
+      "Jinja",
+      "Kabale",
+      "Kabarole",
+      "Kaberamaido",
+      "Kalangala",
+      "Kampala",
+      "Kamuli",
+      "Kamwenge",
+      "Kanungu",
+      "Kapchorwa",
+      "Kasese",
+      "Katakwi",
+      "Kayunga",
+      "Kibale",
+      "Kiboga",
+      "Kisoro",
+      "Kitgum",
+      "Kotido",
+      "Kumi",
+      "Kyenjojo",
+      "Lira",
+      "Luwero",
+      "Masaka",
+      "Masindi",
+      "Mayuge",
+      "Mbale",
+      "Mbarara",
+      "Moroto",
+      "Moyo",
+      "Mpigi",
+      "Mubende",
+      "Mukono",
+      "Nakapiripirit",
+      "Nakasongola",
+      "Nebbi",
+      "Ntungamo",
+      "Pader",
+      "Pallisa",
+      "Rakai",
+      "Rukungiri",
+      "Sembabule",
+      "Sironko",
+      "Soroti",
+      "Tororo",
+      "Wakiso",
+      "Yumbe"
+    ],
+    "country_code": "UG"
+  },
+  {
+    "country": "Ukraine",
+    "states": [
+      "Cherkasy",
+      "Chernihiv",
+      "Chernivtsi",
+      "Crimea",
+      "Dnipropetrovs'k",
+      "Donets'k",
+      "Ivano-Frankivs'k",
+      "Kharkiv",
+      "Kherson",
+      "Khmel'nyts'kyy",
+      "Kirovohrad",
+      "Kiev",
+      "Kyyiv",
+      "Luhans'k",
+      "L'viv",
+      "Mykolayiv",
+      "Odesa",
+      "Poltava",
+      "Rivne",
+      "Sevastopol'",
+      "Sumy",
+      "Ternopil'",
+      "Vinnytsya",
+      "Volyn'",
+      "Zakarpattya",
+      "Zaporizhzhya",
+      "Zhytomyr"
+    ],
+    "country_code": "UA"
+  },
+  {
+    "country": "United Arab Emirates",
+    "states": [
+      "Abu Dhabi",
+      "'Ajman",
+      "Al Fujayrah",
+      "Sharjah",
+      "Dubai",
+      "Ra's al Khaymah",
+      "Umm al Qaywayn"
+    ],
+    "country_code": "AE"
+  },
+  {
+    "country": "Uruguay",
+    "states": [
+      "Artigas",
+      "Canelones",
+      "Cerro Largo",
+      "Colonia",
+      "Durazno",
+      "Flores",
+      "Florida",
+      "Lavalleja",
+      "Maldonado",
+      "Montevideo",
+      "Paysandu",
+      "Rio Negro",
+      "Rivera",
+      "Rocha",
+      "Salto",
+      "San Jose",
+      "Soriano",
+      "Tacuarembo",
+      "Treinta y Tres"
+    ],
+    "country_code": "UY"
+  },
+  {
+    "country": "Uzbekistan",
+    "states": [
+      "Andijon Viloyati",
+      "Buxoro Viloyati",
+      "Farg'ona Viloyati",
+      "Jizzax Viloyati",
+      "Namangan Viloyati",
+      "Navoiy Viloyati",
+      "Qashqadaryo Viloyati",
+      "Qaraqalpog'iston Respublikasi",
+      "Samarqand Viloyati",
+      "Sirdaryo Viloyati",
+      "Surxondaryo Viloyati",
+      "Toshkent Shahri",
+      "Toshkent Viloyati",
+      "Xorazm Viloyati"
+    ],
+    "country_code": "UZ"
+  },
+  {
+    "country": "Vanuatu",
+    "states": [
+      "Malampa",
+      "Penama",
+      "Sanma",
+      "Shefa",
+      "Tafea",
+      "Torba"
+    ],
+    "country_code": "VU"
+  },
+  {
+    "country": "Venezuela",
+    "states": [
+      "Amazonas",
+      "Anzoategui",
+      "Apure",
+      "Aragua",
+      "Barinas",
+      "Bolivar",
+      "Carabobo",
+      "Cojedes",
+      "Delta Amacuro",
+      "Dependencias Federales",
+      "Distrito Federal",
+      "Falcon",
+      "Guarico",
+      "Lara",
+      "Merida",
+      "Miranda",
+      "Monagas",
+      "Nueva Esparta",
+      "Portuguesa",
+      "Sucre",
+      "Tachira",
+      "Trujillo",
+      "Vargas",
+      "Yaracuy",
+      "Zulia"
+    ],
+    "country_code": "VE"
+  },
+  {
+    "country": "Viet nam",
+    "states": [
+      "An Giang",
+      "Bac Giang",
+      "Bac Kan",
+      "Bac Lieu",
+      "Bac Ninh",
+      "Ba Ria-Vung Tau",
+      "Ben Tre",
+      "Binh Dinh",
+      "Binh Duong",
+      "Binh Phuoc",
+      "Binh Thuan",
+      "Ca Mau",
+      "Cao Bang",
+      "Dac Lak",
+      "Dac Nong",
+      "Dien Bien",
+      "Dong Nai",
+      "Dong Thap",
+      "Gia Lai",
+      "Ha Giang",
+      "Hai Duong",
+      "Ha Nam",
+      "Ha Tay",
+      "Ha Tinh",
+      "Hau Giang",
+      "Hoa Binh",
+      "Hung Yen",
+      "Khanh Hoa",
+      "Kien Giang",
+      "Kon Tum",
+      "Lai Chau",
+      "Lam Dong",
+      "Lang Son",
+      "Lao Cai",
+      "Long An",
+      "Nam Dinh",
+      "Nghe An",
+      "Ninh Binh",
+      "Ninh Thuan",
+      "Phu Tho",
+      "Phu Yen",
+      "Quang Binh",
+      "Quang Nam",
+      "Quang Ngai",
+      "Quang Ninh",
+      "Quang Tri",
+      "Soc Trang",
+      "Son La",
+      "Tay Ninh",
+      "Thai Binh",
+      "Thai Nguyen",
+      "Thanh Hoa",
+      "Thua Thien-Hue",
+      "Tien Giang",
+      "Tra Vinh",
+      "Tuyen Quang",
+      "Vinh Long",
+      "Vinh Phuc",
+      "Yen Bai",
+      "Can Tho",
+      "Da Nang",
+      "Hai Phong",
+      "Hanoi",
+      "Ho Chi Minh"
+    ],
+    "country_code": "VN"
+  },
+  {
+    "country": "Yemen",
+    "states": [
+      "Abyan",
+      "'Adan",
+      "Ad Dali'",
+      "Al Bayda'",
+      "Al Hudaydah",
+      "Al Jawf",
+      "Al Mahrah",
+      "Al Mahwit",
+      "'Amran",
+      "Dhamar",
+      "Hadramawt",
+      "Hajjah",
+      "Ibb",
+      "Lahij",
+      "Ma'rib",
+      "Sa'dah",
+      "San'a'",
+      "Shabwah",
+      "Ta'izz"
+    ],
+    "country_code": "YE"
+  },
+  {
+    "country": "Zambia",
+    "states": [
+      "Central",
+      "Copperbelt",
+      "Eastern",
+      "Luapula",
+      "Lusaka",
+      "Northern",
+      "North-Western",
+      "Southern",
+      "Western"
+    ],
+    "country_code": "ZM"
+  },
+  {
+    "country": "Zimbabwe",
+    "states": [
+      "Bulawayo",
+      "Harare",
+      "Manicaland",
+      "Mashonaland Central",
+      "Mashonaland East",
+      "Mashonaland West",
+      "Masvingo",
+      "Matabeleland North",
+      "Matabeleland South",
+      "Midlands"
+    ],
+    "country_code": "ZW"
+  }
+];
+
+// construct a reverse lookup
+COUNTRY_CODE_LOOKUP = {};
+for (var block of COUNTRIES_LIST) {
+    COUNTRY_CODE_LOOKUP[block['country_code']] = block['country'];
+}

--- a/microsetta_interface/templates/account_details.jinja2
+++ b/microsetta_interface/templates/account_details.jinja2
@@ -62,65 +62,23 @@
             var start_code = {{ account.address.state | e | tojson }};
             cc = new JQuerySelectInput("country_code", "#country_code");
             new DelegateOutput(function(code){
+                let current_country = COUNTRY_CODE_LOOKUP[code];
                 if (code == "GB")
                 {
+                    // TODO: remove if/when we add en_GB as a locale
                     $("#city_label").text("Town*");
                     $("#state_label").text("County*");
                     $("#post_code_label").text("Postcode*");
                     $("#state").empty();
-                    for (var country of COUNTRIES_LIST)
-                    {
-                        if (country.country != "United Kingdom")
-                            continue;
-
-                        for (var state of country.states)
-                        {
-                            var option = $('<option></option>')
-                                .attr("value", state)
-                                .text(state);
-
-                            // We don't really have state codes for other
-                            // countries...
-                            if (state == start_code)
-                                option.attr('selected','selected');
-
-                            $("#state").append(option);
-                        }
-                    }
-                }
-                else if (code === "MX") {
+                } else {
                     $("#city_label").text("{{ _('City') }}*");
                     $("#state_label").text("{{ _('State') }}*");
                     $("#post_code_label").text("{{ _('Zip Code') }}*");
                     $("#state").empty();
-
-                    for (var country of COUNTRIES_LIST)
-                    {
-                        if (country.country !== "Mexico")
-                            continue;
-
-                        for (var state of country.states)
-                        {
-                            var option = $('<option></option>')
-                                .attr("value", state)
-                                .text(state);
-
-                            // We don't really have state codes for other
-                            // countries...
-                            if (state == start_code)
-                                option.attr('selected','selected');
-
-                            $("#state").append(option);
-                        }
-                    }
                 }
-                else
-                {
-                    $("#city_label").text("{{ _('City') }}*");
-                    $("#state_label").text("{{ _('State') }}*");
-                    $("#post_code_label").text("{{ _('Zip Code') }}*");
-                    $("#state").empty();
 
+                // special case the use of codes for US states
+                if (code == "US") {
                     for (var state of US_STATES)
                     {
                         var option = $('<option></option>')
@@ -129,6 +87,26 @@
                         if (state[0] == start_code)
                             option.attr('selected','selected');
                         $("#state").append(option);
+                    }
+                } else {
+                    for (var country of COUNTRIES_LIST)
+                    {
+                        if (country.country != current_country)
+                            continue;
+
+                        for (var state of country.states)
+                        {
+                            var option = $('<option></option>')
+                                .attr("value", state)
+                                .text(state);
+
+                            // We don't really have state codes for other
+                            // countries...
+                            if (state == start_code)
+                                option.attr('selected','selected');
+
+                            $("#state").append(option);
+                        }
                     }
                 }
             },cc);
@@ -172,9 +150,198 @@
                 <label for="country_code" id="country_code_label">{{ _('Country') }}*</label>
                 <br>
                 <select id="country_code" name="country_code">
-                    <option value="MX" {% if account.address.country_code == "MX" %} selected {% endif %} >{{ _('Mexico') }}</option>
                     <option value="US" {% if account.address.country_code == "US" %} selected {% endif %} >{{ _('United States') }}</option>
                     <option value="GB" {% if account.address.country_code == "GB" %} selected {% endif %} >{{ _('United Kingdom') }}</option>
+                    <option value="MX" {% if account.address.country_code == "MX" %} selected {% endif %} >{{ _('Mexico') }}</option>
+                    <option value="AF" {% if account.address.country_code == "AF" %} selected {% endif %} >{{ _('Afghanistan') }}</option>
+                    <option value="AL" {% if account.address.country_code == "AL" %} selected {% endif %} >{{ _('Albania') }}</option>
+                    <option value="DZ" {% if account.address.country_code == "DZ" %} selected {% endif %} >{{ _('Algeria') }}</option>
+                    <option value="AD" {% if account.address.country_code == "AD" %} selected {% endif %} >{{ _('Andorra') }}</option>
+                    <option value="AO" {% if account.address.country_code == "AO" %} selected {% endif %} >{{ _('Angola') }}</option>
+                    <option value="AQ" {% if account.address.country_code == "AQ" %} selected {% endif %} >{{ _('Antarctica') }}</option>
+                    <option value="AG" {% if account.address.country_code == "AG" %} selected {% endif %} >{{ _('Antigua and Barbuda') }}</option>
+                    <option value="AR" {% if account.address.country_code == "AR" %} selected {% endif %} >{{ _('Argentina') }}</option>
+                    <option value="AM" {% if account.address.country_code == "AM" %} selected {% endif %} >{{ _('Armenia') }}</option>
+                    <option value="AU" {% if account.address.country_code == "AU" %} selected {% endif %} >{{ _('Australia') }}</option>
+                    <option value="AT" {% if account.address.country_code == "AT" %} selected {% endif %} >{{ _('Austria') }}</option>
+                    <option value="AZ" {% if account.address.country_code == "AZ" %} selected {% endif %} >{{ _('Azerbaijan') }}</option>
+                    <option value="BS" {% if account.address.country_code == "BS" %} selected {% endif %} >{{ _('Bahamas') }}</option>
+                    <option value="BH" {% if account.address.country_code == "BH" %} selected {% endif %} >{{ _('Bahrain') }}</option>
+                    <option value="BD" {% if account.address.country_code == "BD" %} selected {% endif %} >{{ _('Bangladesh') }}</option>
+                    <option value="BB" {% if account.address.country_code == "BB" %} selected {% endif %} >{{ _('Barbados') }}</option>
+                    <option value="BY" {% if account.address.country_code == "BY" %} selected {% endif %} >{{ _('Belarus') }}</option>
+                    <option value="BE" {% if account.address.country_code == "BE" %} selected {% endif %} >{{ _('Belgium') }}</option>
+                    <option value="BZ" {% if account.address.country_code == "BZ" %} selected {% endif %} >{{ _('Belize') }}</option>
+                    <option value="BJ" {% if account.address.country_code == "BJ" %} selected {% endif %} >{{ _('Benin') }}</option>
+                    <option value="BM" {% if account.address.country_code == "BM" %} selected {% endif %} >{{ _('Bermuda') }}</option>
+                    <option value="BT" {% if account.address.country_code == "BT" %} selected {% endif %} >{{ _('Bhutan') }}</option>
+                    <option value="BO" {% if account.address.country_code == "BO" %} selected {% endif %} >{{ _('Bolivia') }}</option>
+                    <option value="BA" {% if account.address.country_code == "BA" %} selected {% endif %} >{{ _('Bosnia and Herzegovina') }}</option>
+                    <option value="BW" {% if account.address.country_code == "BW" %} selected {% endif %} >{{ _('Botswana') }}</option>
+                    <option value="BR" {% if account.address.country_code == "BR" %} selected {% endif %} >{{ _('Brazil') }}</option>
+                    <option value="BN" {% if account.address.country_code == "BN" %} selected {% endif %} >{{ _('Brunei') }}</option>
+                    <option value="BG" {% if account.address.country_code == "BG" %} selected {% endif %} >{{ _('Bulgaria') }}</option>
+                    <option value="BF" {% if account.address.country_code == "BF" %} selected {% endif %} >{{ _('Burkina Faso') }}</option>
+                    <option value="MM" {% if account.address.country_code == "MM" %} selected {% endif %} >{{ _('Burma') }}</option>
+                    <option value="BI" {% if account.address.country_code == "BI" %} selected {% endif %} >{{ _('Burundi') }}</option>
+                    <option value="KH" {% if account.address.country_code == "KH" %} selected {% endif %} >{{ _('Cambodia') }}</option>
+                    <option value="CM" {% if account.address.country_code == "CM" %} selected {% endif %} >{{ _('Cameroon') }}</option>
+                    <option value="CA" {% if account.address.country_code == "CA" %} selected {% endif %} >{{ _('Canada') }}</option>
+                    <option value="CV" {% if account.address.country_code == "CV" %} selected {% endif %} >{{ _('Cape Verde') }}</option>
+                    <option value="CF" {% if account.address.country_code == "CF" %} selected {% endif %} >{{ _('Central African Republic') }}</option>
+                    <option value="TD" {% if account.address.country_code == "TD" %} selected {% endif %} >{{ _('Chad') }}</option>
+                    <option value="CL" {% if account.address.country_code == "CL" %} selected {% endif %} >{{ _('Chile') }}</option>
+                    <option value="CN" {% if account.address.country_code == "CN" %} selected {% endif %} >{{ _('China') }}</option>
+                    <option value="CO" {% if account.address.country_code == "CO" %} selected {% endif %} >{{ _('Colombia') }}</option>
+                    <option value="KM" {% if account.address.country_code == "KM" %} selected {% endif %} >{{ _('Comoros') }}</option>
+                    <option value="CD" {% if account.address.country_code == "CD" %} selected {% endif %} >{{ _('Congo, Democratic Republic') }}</option>
+                    <option value="CG" {% if account.address.country_code == "CG" %} selected {% endif %} >{{ _('Congo, Republic of the') }}</option>
+                    <option value="CR" {% if account.address.country_code == "CR" %} selected {% endif %} >{{ _('Costa Rica') }}</option>
+                    <option value="CI" {% if account.address.country_code == "CI" %} selected {% endif %} >{{ _("Cote d'Ivoire") }}</option>
+                    <option value="HR" {% if account.address.country_code == "HR" %} selected {% endif %} >{{ _('Croatia') }}</option>
+                    <option value="CU" {% if account.address.country_code == "CU" %} selected {% endif %} >{{ _('Cuba') }}</option>
+                    <option value="CY" {% if account.address.country_code == "CY" %} selected {% endif %} >{{ _('Cyprus') }}</option>
+                    <option value="CZ" {% if account.address.country_code == "CZ" %} selected {% endif %} >{{ _('Czech Republic') }}</option>
+                    <option value="DK" {% if account.address.country_code == "DK" %} selected {% endif %} >{{ _('Denmark') }}</option>
+                    <option value="DJ" {% if account.address.country_code == "DJ" %} selected {% endif %} >{{ _('Djibouti') }}</option>
+                    <option value="DM" {% if account.address.country_code == "DM" %} selected {% endif %} >{{ _('Dominica') }}</option>
+                    <option value="DO" {% if account.address.country_code == "DO" %} selected {% endif %} >{{ _('Dominican Republic') }}</option>
+                    <option value="TL" {% if account.address.country_code == "TL" %} selected {% endif %} >{{ _('East Timor') }}</option>
+                    <option value="EC" {% if account.address.country_code == "EC" %} selected {% endif %} >{{ _('Ecuador') }}</option>
+                    <option value="EG" {% if account.address.country_code == "EG" %} selected {% endif %} >{{ _('Egypt') }}</option>
+                    <option value="SV" {% if account.address.country_code == "SV" %} selected {% endif %} >{{ _('El Salvador') }}</option>
+                    <option value="GQ" {% if account.address.country_code == "GQ" %} selected {% endif %} >{{ _('Equatorial Guinea') }}</option>
+                    <option value="ER" {% if account.address.country_code == "ER" %} selected {% endif %} >{{ _('Eritrea') }}</option>
+                    <option value="EE" {% if account.address.country_code == "EE" %} selected {% endif %} >{{ _('Estonia') }}</option>
+                    <option value="ET" {% if account.address.country_code == "ET" %} selected {% endif %} >{{ _('Ethiopia') }}</option>
+                    <option value="FJ" {% if account.address.country_code == "FJ" %} selected {% endif %} >{{ _('Fiji') }}</option>
+                    <option value="FI" {% if account.address.country_code == "FI" %} selected {% endif %} >{{ _('Finland') }}</option>
+                    <option value="FR" {% if account.address.country_code == "FR" %} selected {% endif %} >{{ _('France') }}</option>
+                    <option value="GA" {% if account.address.country_code == "GA" %} selected {% endif %} >{{ _('Gabon') }}</option>
+                    <option value="GM" {% if account.address.country_code == "GM" %} selected {% endif %} >{{ _('Gambia') }}</option>
+                    <option value="GE" {% if account.address.country_code == "GE" %} selected {% endif %} >{{ _('Georgia') }}</option>
+                    <option value="DE" {% if account.address.country_code == "DE" %} selected {% endif %} >{{ _('Germany') }}</option>
+                    <option value="GH" {% if account.address.country_code == "GH" %} selected {% endif %} >{{ _('Ghana') }}</option>
+                    <option value="GR" {% if account.address.country_code == "GR" %} selected {% endif %} >{{ _('Greece') }}</option>
+                    <option value="GL" {% if account.address.country_code == "GL" %} selected {% endif %} >{{ _('Greenland') }}</option>
+                    <option value="GD" {% if account.address.country_code == "GD" %} selected {% endif %} >{{ _('Grenada') }}</option>
+                    <option value="GT" {% if account.address.country_code == "GT" %} selected {% endif %} >{{ _('Guatemala') }}</option>
+                    <option value="GN" {% if account.address.country_code == "GN" %} selected {% endif %} >{{ _('Guinea') }}</option>
+                    <option value="GW" {% if account.address.country_code == "GW" %} selected {% endif %} >{{ _('Guinea-Bissau') }}</option>
+                    <option value="GY" {% if account.address.country_code == "GY" %} selected {% endif %} >{{ _('Guyana') }}</option>
+                    <option value="HT" {% if account.address.country_code == "HT" %} selected {% endif %} >{{ _('Haiti') }}</option>
+                    <option value="HN" {% if account.address.country_code == "HN" %} selected {% endif %} >{{ _('Honduras') }}</option>
+                    <option value="HK" {% if account.address.country_code == "HK" %} selected {% endif %} >{{ _('Hong Kong') }}</option>
+                    <option value="HU" {% if account.address.country_code == "HU" %} selected {% endif %} >{{ _('Hungary') }}</option>
+                    <option value="IS" {% if account.address.country_code == "IS" %} selected {% endif %} >{{ _('Iceland') }}</option>
+                    <option value="IN" {% if account.address.country_code == "IN" %} selected {% endif %} >{{ _('India') }}</option>
+                    <option value="ID" {% if account.address.country_code == "ID" %} selected {% endif %} >{{ _('Indonesia') }}</option>
+                    <option value="IR" {% if account.address.country_code == "IR" %} selected {% endif %} >{{ _('Iran') }}</option>
+                    <option value="IQ" {% if account.address.country_code == "IQ" %} selected {% endif %} >{{ _('Iraq') }}</option>
+                    <option value="IE" {% if account.address.country_code == "IE" %} selected {% endif %} >{{ _('Ireland') }}</option>
+                    <option value="IL" {% if account.address.country_code == "IL" %} selected {% endif %} >{{ _('Israel') }}</option>
+                    <option value="IT" {% if account.address.country_code == "IT" %} selected {% endif %} >{{ _('Italy') }}</option>
+                    <option value="JM" {% if account.address.country_code == "JM" %} selected {% endif %} >{{ _('Jamaica') }}</option>
+                    <option value="JP" {% if account.address.country_code == "JP" %} selected {% endif %} >{{ _('Japan') }}</option>
+                    <option value="JO" {% if account.address.country_code == "JO" %} selected {% endif %} >{{ _('Jordan') }}</option>
+                    <option value="KZ" {% if account.address.country_code == "KZ" %} selected {% endif %} >{{ _('Kazakhstan') }}</option>
+                    <option value="KE" {% if account.address.country_code == "KE" %} selected {% endif %} >{{ _('Kenya') }}</option>
+                    <option value="KI" {% if account.address.country_code == "KI" %} selected {% endif %} >{{ _('Kiribati') }}</option>
+                    <option value="KP" {% if account.address.country_code == "KP" %} selected {% endif %} >{{ _('Korea North') }}</option>
+                    <option value="KR" {% if account.address.country_code == "KR" %} selected {% endif %} >{{ _('Korea South') }}</option>
+                    <option value="KW" {% if account.address.country_code == "KW" %} selected {% endif %} >{{ _('Kuwait') }}</option>
+                    <option value="KG" {% if account.address.country_code == "KG" %} selected {% endif %} >{{ _('Kyrgyzstan') }}</option>
+                    <option value="LA" {% if account.address.country_code == "LA" %} selected {% endif %} >{{ _('Laos') }}</option>
+                    <option value="LV" {% if account.address.country_code == "LV" %} selected {% endif %} >{{ _('Latvia') }}</option>
+                    <option value="LB" {% if account.address.country_code == "LB" %} selected {% endif %} >{{ _('Lebanon') }}</option>
+                    <option value="LS" {% if account.address.country_code == "LS" %} selected {% endif %} >{{ _('Lesotho') }}</option>
+                    <option value="LR" {% if account.address.country_code == "LR" %} selected {% endif %} >{{ _('Liberia') }}</option>
+                    <option value="LY" {% if account.address.country_code == "LY" %} selected {% endif %} >{{ _('Libya') }}</option>
+                    <option value="LI" {% if account.address.country_code == "LI" %} selected {% endif %} >{{ _('Liechtenstein') }}</option>
+                    <option value="LT" {% if account.address.country_code == "LT" %} selected {% endif %} >{{ _('Lithuania') }}</option>
+                    <option value="LU" {% if account.address.country_code == "LU" %} selected {% endif %} >{{ _('Luxembourg') }}</option>
+                    <option value="MK" {% if account.address.country_code == "MK" %} selected {% endif %} >{{ _('Macedonia') }}</option>
+                    <option value="MG" {% if account.address.country_code == "MG" %} selected {% endif %} >{{ _('Madagascar') }}</option>
+                    <option value="MW" {% if account.address.country_code == "MW" %} selected {% endif %} >{{ _('Malawi') }}</option>
+                    <option value="MY" {% if account.address.country_code == "MY" %} selected {% endif %} >{{ _('Malaysia') }}</option>
+                    <option value="MV" {% if account.address.country_code == "MV" %} selected {% endif %} >{{ _('Maldives') }}</option>
+                    <option value="ML" {% if account.address.country_code == "ML" %} selected {% endif %} >{{ _('Mali') }}</option>
+                    <option value="MT" {% if account.address.country_code == "MT" %} selected {% endif %} >{{ _('Malta') }}</option>
+                    <option value="MH" {% if account.address.country_code == "MH" %} selected {% endif %} >{{ _('Marshall Islands') }}</option>
+                    <option value="MR" {% if account.address.country_code == "MR" %} selected {% endif %} >{{ _('Mauritania') }}</option>
+                    <option value="MU" {% if account.address.country_code == "MU" %} selected {% endif %} >{{ _('Mauritius') }}</option>
+                    <option value="FM" {% if account.address.country_code == "FM" %} selected {% endif %} >{{ _('Micronesia') }}</option>
+                    <option value="MD" {% if account.address.country_code == "MD" %} selected {% endif %} >{{ _('Moldova') }}</option>
+                    <option value="MN" {% if account.address.country_code == "MN" %} selected {% endif %} >{{ _('Mongolia') }}</option>
+                    <option value="ME" {% if account.address.country_code == "ME" %} selected {% endif %} >{{ _('Montenegro') }}</option>
+                    <option value="MA" {% if account.address.country_code == "MA" %} selected {% endif %} >{{ _('Morocco') }}</option>
+                    <option value="MC" {% if account.address.country_code == "MC" %} selected {% endif %} >{{ _('Monaco') }}</option>
+                    <option value="MZ" {% if account.address.country_code == "MZ" %} selected {% endif %} >{{ _('Mozambique') }}</option>
+                    <option value="NA" {% if account.address.country_code == "NA" %} selected {% endif %} >{{ _('Namibia') }}</option>
+                    <option value="NR" {% if account.address.country_code == "NR" %} selected {% endif %} >{{ _('Nauru') }}</option>
+                    <option value="NP" {% if account.address.country_code == "NP" %} selected {% endif %} >{{ _('Nepal') }}</option>
+                    <option value="NL" {% if account.address.country_code == "NL" %} selected {% endif %} >{{ _('Netherlands') }}</option>
+                    <option value="NZ" {% if account.address.country_code == "NZ" %} selected {% endif %} >{{ _('New Zealand') }}</option>
+                    <option value="NI" {% if account.address.country_code == "NI" %} selected {% endif %} >{{ _('Nicaragua') }}</option>
+                    <option value="NE" {% if account.address.country_code == "NE" %} selected {% endif %} >{{ _('Niger') }}</option>
+                    <option value="NG" {% if account.address.country_code == "NG" %} selected {% endif %} >{{ _('Nigeria') }}</option>
+                    <option value="NO" {% if account.address.country_code == "NO" %} selected {% endif %} >{{ _('Norway') }}</option>
+                    <option value="OM" {% if account.address.country_code == "OM" %} selected {% endif %} >{{ _('Oman') }}</option>
+                    <option value="PK" {% if account.address.country_code == "PK" %} selected {% endif %} >{{ _('Pakistan') }}</option>
+                    <option value="PA" {% if account.address.country_code == "PA" %} selected {% endif %} >{{ _('Panama') }}</option>
+                    <option value="PG" {% if account.address.country_code == "PG" %} selected {% endif %} >{{ _('Papua New Guinea') }}</option>
+                    <option value="PY" {% if account.address.country_code == "PY" %} selected {% endif %} >{{ _('Paraguay') }}</option>
+                    <option value="PE" {% if account.address.country_code == "PE" %} selected {% endif %} >{{ _('Peru') }}</option>
+                    <option value="PH" {% if account.address.country_code == "PH" %} selected {% endif %} >{{ _('Philippines') }}</option>
+                    <option value="PL" {% if account.address.country_code == "PL" %} selected {% endif %} >{{ _('Poland') }}</option>
+                    <option value="PT" {% if account.address.country_code == "PT" %} selected {% endif %} >{{ _('Portugal') }}</option>
+                    <option value="QA" {% if account.address.country_code == "QA" %} selected {% endif %} >{{ _('Qatar') }}</option>
+                    <option value="RO" {% if account.address.country_code == "RO" %} selected {% endif %} >{{ _('Romania') }}</option>
+                    <option value="RU" {% if account.address.country_code == "RU" %} selected {% endif %} >{{ _('Russia') }}</option>
+                    <option value="RW" {% if account.address.country_code == "RW" %} selected {% endif %} >{{ _('Rwanda') }}</option>
+                    <option value="WS" {% if account.address.country_code == "WS" %} selected {% endif %} >{{ _('Samoa') }}</option>
+                    <option value="SM" {% if account.address.country_code == "SM" %} selected {% endif %} >{{ _('San Marino') }}</option>
+                    <option value="ST" {% if account.address.country_code == "ST" %} selected {% endif %} >{{ _('Sao Tome') }}</option>
+                    <option value="SA" {% if account.address.country_code == "SA" %} selected {% endif %} >{{ _('Saudi Arabia') }}</option>
+                    <option value="SN" {% if account.address.country_code == "SN" %} selected {% endif %} >{{ _('Senegal') }}</option>
+                    <option value="RS" {% if account.address.country_code == "RS" %} selected {% endif %} >{{ _('Serbia') }}</option>
+                    <option value="SC" {% if account.address.country_code == "SC" %} selected {% endif %} >{{ _('Seychelles') }}</option>
+                    <option value="SL" {% if account.address.country_code == "SL" %} selected {% endif %} >{{ _('Sierra Leone') }}</option>
+                    <option value="SG" {% if account.address.country_code == "SG" %} selected {% endif %} >{{ _('Singapore') }}</option>
+                    <option value="SK" {% if account.address.country_code == "SK" %} selected {% endif %} >{{ _('Slovakia') }}</option>
+                    <option value="SI" {% if account.address.country_code == "SI" %} selected {% endif %} >{{ _('Slovenia') }}</option>
+                    <option value="SB" {% if account.address.country_code == "SB" %} selected {% endif %} >{{ _('Solomon Islands') }}</option>
+                    <option value="SO" {% if account.address.country_code == "SO" %} selected {% endif %} >{{ _('Somalia') }}</option>
+                    <option value="ZA" {% if account.address.country_code == "ZA" %} selected {% endif %} >{{ _('South Africa') }}</option>
+                    <option value="ES" {% if account.address.country_code == "ES" %} selected {% endif %} >{{ _('Spain') }}</option>
+                    <option value="LK" {% if account.address.country_code == "LK" %} selected {% endif %} >{{ _('Sri Lanka') }}</option>
+                    <option value="SD" {% if account.address.country_code == "SD" %} selected {% endif %} >{{ _('Sudan') }}</option>
+                    <option value="SR" {% if account.address.country_code == "SR" %} selected {% endif %} >{{ _('Suriname') }}</option>
+                    <option value="SZ" {% if account.address.country_code == "SZ" %} selected {% endif %} >{{ _('Swaziland') }}</option>
+                    <option value="SE" {% if account.address.country_code == "SE" %} selected {% endif %} >{{ _('Sweden') }}</option>
+                    <option value="CH" {% if account.address.country_code == "CH" %} selected {% endif %} >{{ _('Switzerland') }}</option>
+                    <option value="SY" {% if account.address.country_code == "SY" %} selected {% endif %} >{{ _('Syria') }}</option>
+                    <option value="TW" {% if account.address.country_code == "TW" %} selected {% endif %} >{{ _('Taiwan') }}</option>
+                    <option value="TJ" {% if account.address.country_code == "TJ" %} selected {% endif %} >{{ _('Tajikistan') }}</option>
+                    <option value="TZ" {% if account.address.country_code == "TZ" %} selected {% endif %} >{{ _('Tanzania') }}</option>
+                    <option value="TH" {% if account.address.country_code == "TH" %} selected {% endif %} >{{ _('Thailand') }}</option>
+                    <option value="TG" {% if account.address.country_code == "TG" %} selected {% endif %} >{{ _('Togo') }}</option>
+                    <option value="TO" {% if account.address.country_code == "TO" %} selected {% endif %} >{{ _('Tonga') }}</option>
+                    <option value="TT" {% if account.address.country_code == "TT" %} selected {% endif %} >{{ _('Trinidad and Tobago') }}</option>
+                    <option value="TN" {% if account.address.country_code == "TN" %} selected {% endif %} >{{ _('Tunisia') }}</option>
+                    <option value="TR" {% if account.address.country_code == "TR" %} selected {% endif %} >{{ _('Turkey') }}</option>
+                    <option value="TM" {% if account.address.country_code == "TM" %} selected {% endif %} >{{ _('Turkmenistan') }}</option>
+                    <option value="UG" {% if account.address.country_code == "UG" %} selected {% endif %} >{{ _('Uganda') }}</option>
+                    <option value="UA" {% if account.address.country_code == "UA" %} selected {% endif %} >{{ _('Ukraine') }}</option>
+                    <option value="AE" {% if account.address.country_code == "AE" %} selected {% endif %} >{{ _('United Arab Emirates') }}</option>
+                    <option value="UY" {% if account.address.country_code == "UY" %} selected {% endif %} >{{ _('Uruguay') }}</option>
+                    <option value="UZ" {% if account.address.country_code == "UZ" %} selected {% endif %} >{{ _('Uzbekistan') }}</option>
+                    <option value="VU" {% if account.address.country_code == "VU" %} selected {% endif %} >{{ _('Vanuatu') }}</option>
+                    <option value="VE" {% if account.address.country_code == "VE" %} selected {% endif %} >{{ _('Venezuela') }}</option>
+                    <option value="VN" {% if account.address.country_code == "VN" %} selected {% endif %} >{{ _('Viet nam') }}</option>
+                    <option value="YE" {% if account.address.country_code == "YE" %} selected {% endif %} >{{ _('Yemen') }}</option>
+                    <option value="ZM" {% if account.address.country_code == "ZM" %} selected {% endif %} >{{ _('Zambia') }}</option>
+                    <option value="ZW" {% if account.address.country_code == "ZW" %} selected {% endif %} >{{ _('Zimbabwe') }}</option>
                 </select>
             </div>
             <div class="form-group">

--- a/microsetta_interface/templates/account_details.jinja2
+++ b/microsetta_interface/templates/account_details.jinja2
@@ -70,10 +70,15 @@
                     $("#state_label").text("County*");
                     $("#post_code_label").text("Postcode*");
                     $("#state").empty();
-                } else {
+                } else if (code == "US") {
                     $("#city_label").text("{{ _('City') }}*");
                     $("#state_label").text("{{ _('State') }}*");
                     $("#post_code_label").text("{{ _('Zip Code') }}*");
+                    $("#state").empty();
+                } else {
+                    $("#city_label").text("{{ _('City/Town') }}*");
+                    $("#state_label").text("{{ _('County/State') }}*");
+                    $("#post_code_label").text("{{ _('Postcode') }}*");
                     $("#state").empty();
                 }
 


### PR DESCRIPTION
Represent country code, allow for selection of countries outside of US/GB/MX.

This modifies `COUNTRY_LIST` to include `country_code`. Codes were sourced from [w3schools](https://www.w3schools.com/tags/ref_country_codes.asp) first by exact name match to country name then manually resolving those that did not match (e.g., Congo). 

A `COUNTRY_CODE_LOOKUP` is also now constructed to simplify pulling out state information. 

Last, the selection field is prioritized for US/GB/MX as we have representation there now, and the remaining entries are alphabetical -- it was much easier to hard code these than do it dynamically as we have to take care of the i18n calls.