### PR TITLE
Setup an integration test harness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
         pip install -r ci/pip_requirements.txt
         pip install -e . --no-deps
         
-        git clone git@github.com:biocore/microsetta-private-api.git
+        git clone https://github.com/biocore/microsetta-private-api.git
         pushd microsetta-private-api
         pgport=${{ job.services.postgres.ports[5432] }}
         sed -i "s/self.port = 5432/self.port = $pgport/" microsetta_private_api/config_manager.py
@@ -117,6 +117,7 @@ jobs:
         popd
 
         conda activate microsetta-interface
+        source keys_for_testing.sh
         python microsetta_interface/tests/test_integration.py 2> >(tee -a stderr.log >&2)
         
         # make sure we did not skip tests, which would indicate a failure in

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,11 @@ jobs:
         pushd microsetta-private-api
         sed -i 's/"debug": true,/"debug": true, "disable_authentication": true,/' microsetta_private_api/server_config.json
         python microsetta_private_api/server.py &
+        sleep 1
         popd
+
+        # make sure we're online
+        curl -v http://localhost:8082/api/ui
 
         conda activate microsetta-interface
         source keys_for_testing.sh
@@ -123,4 +127,4 @@ jobs:
         # make sure we did not skip tests, which would indicate a failure in
         # the harness. this test will produce an exit status of 1 if the
         # test suite reports skipped tests
-        [[ $(tail -n 1 foo | grep skipped) == "" ]];
+        [[ $(tail -n 1 stderr.log | grep skipped) == "" ]];

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
         pip install -r ci/pip_requirements.txt
         pip install -e . --no-deps
         
-        git clone git@github.com/biocore/microsetta-private-api.git
+        git clone git@github.com:biocore/microsetta-private-api.git
         pushd microsetta-private-api
         pgport=${{ job.services.postgres.ports[5432] }}
         sed -i "s/self.port = 5432/self.port = $pgport/" microsetta_private_api/config_manager.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
         pushd microsetta-private-api
         sed -i 's/"debug": true,/"debug": true, "disable_authentication": true,/' microsetta_private_api/server_config.json
         python microsetta_private_api/server.py &
-        sleep 1
+        sleep 10 # give time to start up
         popd
 
         # make sure we're online

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,7 @@ jobs:
         conda activate microsetta-interface
         conda install --yes --file ci/conda_requirements.txt
         pip install -r ci/pip_requirements.txt
+        python setup.py compile_catalog
         pip install -e . --no-deps
         
         git clone https://github.com/biocore/microsetta-private-api.git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,10 +117,8 @@ jobs:
         sleep 10 # give time to start up
         popd
 
-        # make sure we're online
-        curl -v http://localhost:8082/api/ui
-
         conda activate microsetta-interface
+        redis-server --daemonize yes
         source keys_for_testing.sh
         python microsetta_interface/tests/test_integration.py 2> >(tee -a stderr.log >&2)
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,3 +46,80 @@ jobs:
       run: |
         conda activate test-microsetta-interface
         pytest
+  integration:
+    runs-on: ubuntu-latest
+      
+    # Service containers to run with `runner-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres:13.4
+        env:
+          POSTGRES_DB: ag_test  
+          POSTGRES_USER: postgres  
+          POSTGRES_PASSWORD: postgres
+          
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # based on https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L44-L72
+          - 5432/tcp
+
+    steps:
+    # Downloads a copy of the code in your repository before running CI tests
+    - name: Check out repository code
+      uses: actions/checkout@v2
+
+    - name: Setup for conda
+      uses: conda-incubator/setup-miniconda@v2
+      with:        
+        auto-update-conda: true
+        python-version: 3.7 
+    
+    - name: Install
+      shell: bash -l {0}
+      run: |
+        conda create --yes -n microsetta-interface python=3.7
+        conda activate microsetta-interface
+        conda install --yes --file ci/conda_requirements.txt
+        pip install -r ci/pip_requirements.txt
+        pip install -e . --no-deps
+        
+        git clone git@github.com/biocore/microsetta-private-api.git
+        pushd microsetta-private-api
+        pgport=${{ job.services.postgres.ports[5432] }}
+        sed -i "s/self.port = 5432/self.port = $pgport/" microsetta_private_api/config_manager.py
+        
+        # PGPASSWORD is read by pg_restore, which is called by the build_db process. 
+        export PGPASSWORD=postgres
+        
+        conda create --yes -n microsetta-private-api python=3.7
+        conda activate microsetta-private-api
+        conda install --yes --file ci/conda_requirements.txt
+        pip install -r ci/pip_requirements.txt
+        pip install -e . --no-deps 
+        
+        # establish database state
+        python microsetta_private_api/LEGACY/build_db.py
+        popd
+    - name: Run integration tests
+      shell: bash -l {0}
+      run: |
+        conda activate microsetta-private-api
+        pushd microsetta-private-api
+        sed -i 's/"debug": true,/"debug": true, "disable_authentication": true,/' microsetta_private_api/server_config.json
+        python microsetta_private_api/server.py &
+        popd
+
+        conda activate microsetta-interface
+        python microsetta_interface/tests/test_integration.py 2> >(tee -a stderr.log >&2)
+        
+        # make sure we did not skip tests, which would indicate a failure in
+        # the harness. this test will produce an exit status of 1 if the
+        # test suite reports skipped tests
+        [[ $(tail -n 1 foo | grep skipped) == "" ]];

--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ In order for the interface to be functional, it needs to be able to communicate
 with an instance of `microsetta_private_api`. Details for installing and
 running the private API can be found
 [here](https://github.com/biocore/microsetta-private-api/blob/master/README.md#installation).
+
+## Integration tests
+
+An integration test suite is available which exercises the interaction between microsetta-interface and microsetta-private-api. These tests are only run if the private API appears online and accessible, and if custom public/private keys are available for managing JWTs.
+
+To execute the integration suite:
+
+* modify the `server_config.json` of microsetta-private-api, adding `"disable_authentication": true"`. 
+* start microsetta-private-api
+* construct new public/private keys and make them available with `source keys_for_testing.sh`
+* run the integration suite with `python microsetta_interface/tests/test_integration.py`.
+
+If communication with the private API is working, and if public/private keys are accessible, the tests will run. Otherwise, the test suite will skip all tests.

--- a/keys_for_testing.sh
+++ b/keys_for_testing.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cwd=$(pwd)
+export MICROSETTA_INTERFACE_DEBUG_JWT_PUB=${cwd}/jwtRS256.key.pub
+export MICROSETTA_INTERFACE_DEBUG_JWT_PRIV=${cwd}/jwtRS256.key
+
+# based on https://gist.github.com/ygotthilf/baa58da5c3dd1f69fae9
+# and https://unix.stackexchange.com/a/69318
+ssh-keygen -t rsa -b 4096 -m PEM -f ${MICROSETTA_INTERFACE_DEBUG_JWT_PRIV} -N ""
+openssl rsa -in ${MICROSETTA_INTERFACE_DEBUG_JWT_PRIV} -pubout -outform PEM -out ${MICROSETTA_INTERFACE_DEBUG_JWT_PUB}

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -1,5 +1,6 @@
 import json
 
+import os
 import flask
 import flask_babel
 from flask_babel import gettext
@@ -39,9 +40,14 @@ class Source:
     SOURCE_TYPE_ENVIRONMENT = "environmental"
 
 
-PUB_KEY = pkg_resources.read_text(
-    'microsetta_interface',
-    "authrocket.pubkey")
+PUBKEY_ENVVAR = 'MICROSETTA_INTERFACE_DEBUG_JWT_PUB'
+if os.environ.get(PUBKEY_ENVVAR, False):
+    PUB_KEY = open(os.environ[PUBKEY_ENVVAR]).read()
+else:
+    PUB_KEY = pkg_resources.read_text(
+        'microsetta_interface',
+        "authrocket.pubkey")
+
 
 TOKEN_KEY_NAME = 'token'
 ADMIN_MODE_KEY = 'admin_mode'

--- a/microsetta_interface/tests/test_integration.py
+++ b/microsetta_interface/tests/test_integration.py
@@ -29,13 +29,14 @@ else:
 
 
 def _fake_jwt(email, verified):
-    # lie and say we're from authrocket
-    payload = {'email': email,
-               'email_verified': verified,
-               'iss': 'https://authrocket.com',
-               'sub': hashlib.md5(email.encode('ascii')).hexdigest()}
-    encoded = jwt.encode(payload, PRIV_KEY, algorithm='RS256')
-    return encoded
+    if PRIVATE_API_AVAILABLE:
+        # lie and say we're from authrocket
+        payload = {'email': email,
+                   'email_verified': verified,
+                   'iss': 'https://authrocket.com',
+                   'sub': hashlib.md5(email.encode('ascii')).hexdigest()}
+        encoded = jwt.encode(payload, PRIV_KEY, algorithm='RS256')
+        return encoded
 
 
 # we cannot have fine grain control over the state of the private-api

--- a/microsetta_interface/tests/test_integration.py
+++ b/microsetta_interface/tests/test_integration.py
@@ -19,6 +19,8 @@ except:  # noqa
 else:
     PRIVATE_API_AVAILABLE = (req.status_code == 200)
 
+
+# obtain the JWT key if it exists
 PRIVKEY_ENVVAR = 'MICROSETTA_INTERFACE_DEBUG_JWT_PRIV'
 if os.environ.get(PRIVKEY_ENVVAR, False):
     PRIV_KEY = open(os.environ[PRIVKEY_ENVVAR]).read()

--- a/microsetta_interface/tests/test_integration.py
+++ b/microsetta_interface/tests/test_integration.py
@@ -1,0 +1,158 @@
+import unittest
+import hashlib
+import os
+import uuid
+from unittest.mock import patch
+import jwt
+from microsetta_interface.server import app
+from microsetta_interface.implementation import TOKEN_KEY_NAME
+from microsetta_interface.config_manager import SERVER_CONFIG
+import requests
+
+
+# check if microsetta-private-api appears to be running
+PRIVATE_API_AVAILABLE = False
+try:
+    req = requests.get(SERVER_CONFIG['private_api_endpoint'] + '/ui')
+except:  # noqa
+    PRIVATE_API_AVAILABLE = False
+else:
+    PRIVATE_API_AVAILABLE = (req.status_code == 200)
+
+PRIVKEY_ENVVAR = 'MICROSETTA_INTERFACE_DEBUG_JWT_PRIV'
+if os.environ.get(PRIVKEY_ENVVAR, False):
+    PRIV_KEY = open(os.environ[PRIVKEY_ENVVAR]).read()
+else:
+    PRIVATE_API_AVAILABLE = False
+
+
+def _fake_jwt(email, verified):
+    # lie and say we're from authrocket
+    payload = {'email': email,
+               'email_verified': verified,
+               'iss': 'https://authrocket.com',
+               'sub': hashlib.md5(email.encode('ascii')).hexdigest()}
+    encoded = jwt.encode(payload, PRIV_KEY, algorithm='RS256')
+    return encoded
+
+
+# we cannot have fine grain control over the state of the private-api
+# during integration testing. we also do not have control over the
+# order in which tests are executed. as such, treat each user with
+# care, and define new users on an as need basis.
+USER_NEW_EMAIL = 'user_new@foo.bar'
+USER_NEW = _fake_jwt(USER_NEW_EMAIL, True)
+
+USER_NEW_UNVERIFIED_EMAIL = 'user_unverified@foo.bar'
+USER_NEW_UNVERIFIED = _fake_jwt(USER_NEW_UNVERIFIED_EMAIL, False)
+
+USER_WITH_VALID_SAMPLE_EMAIL = "th-dq)wort@3'rey.i3l"
+USER_WITH_VALID_SAMPLE = _fake_jwt(USER_WITH_VALID_SAMPLE_EMAIL, True)
+
+
+@unittest.skipIf(not PRIVATE_API_AVAILABLE,
+                 "An instance of microsetta-private-api is not available")
+class IntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.patch_for_session = patch("microsetta_interface."
+                                       "implementation.session",
+                                       dict())
+        self.mock_session = self.patch_for_session.start()
+
+        app.app.testing = True
+        app.app.config['SECRET_KEY'] = 'secretsecret'
+        self.app = app.app.test_client()
+        self.app.__enter__()
+
+    def tearDown(self):
+        self.patch_for_session.stop()
+        self._logout()
+        self.app.__exit__(None, None, None)
+
+    def _html_page(self, resp):
+        return resp.get_data(as_text=True)
+
+    def _login(self, token):
+        self.mock_session[TOKEN_KEY_NAME] = token
+
+    def _logout(self):
+        try:
+            self.mock_session.pop(TOKEN_KEY_NAME)
+        except KeyError:
+            pass
+
+    def test_home(self):
+        # verify we access
+        resp = self.app.get('/home')
+        data = self._html_page(resp)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('Sign Up', data)
+
+    def test_home_es_mx(self):
+        # make sure things come through in spanish
+        resp = self.app.get('/home', headers={'Accept-Language': 'es_MX'})
+        data = self._html_page(resp)
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn('Sign Up', data)
+        self.assertIn('Registrarse', data)
+
+    def test_new_user(self):
+        # we should get /home for login if we are not already logged in
+        resp = self.app.get('/home')
+        self.assertEqual(resp.status_code, 200)
+
+        self._login(USER_NEW)
+
+        # once logged in, we should redirect
+        resp = self.app.get('/home')
+        self.assertEqual(resp.status_code, 302)
+
+        # this is a new user, so they should go to the account creation page
+        new_url = resp.headers['Location']
+        self.assertTrue(new_url.endswith('create_account'))
+
+        # make sure the creation page loads
+        resp = self.app.get(new_url)
+        self.assertEqual(resp.status_code, 200)
+        data = self._html_page(resp)
+        self.assertIn('<title>Microsetta Account Details</title>', data)
+
+        # once logged out, we should not redirect and instead be at home
+        self._logout()
+        resp = self.app.get('/home')
+        self.assertEqual(resp.status_code, 200)
+
+    def test_new_user_unverified(self):
+        self._login(USER_NEW_UNVERIFIED)
+
+        resp = self.app.get('/home')
+        self.assertEqual(resp.status_code, 200)
+
+        # email is unverified so user should get the corresponding page
+        data = self._html_page(resp)
+        self.assertIn('<title>Microsetta Awaiting Email Confirmation</title>',
+                      data)
+
+    def test_user_with_valid_sample(self):
+        self._login(USER_WITH_VALID_SAMPLE)
+
+        resp = self.app.get('/home')
+        data = self._html_page(resp)
+        self.assertEqual(resp.status_code, 302)
+
+        new_url = resp.headers['Location']
+        uuid_test = new_url.rsplit('/', 1)[1]
+
+        # we should route to the accounts page, which ends with a valid UUID
+        # this test will raise if uuid_test is not a UUID4
+        uuid.UUID(uuid_test, version=4)
+
+        # we should now be on the source listing page
+        resp = self.app.get(new_url)
+        self.assertEqual(resp.status_code, 200)
+        data = self._html_page(resp)
+        self.assertIn('<title>Microsetta Account</title>', data)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR couples with biocore/microsetta-private-api#412 to provide a means for running integration tests within Github Actions (and locally as well).

There are a few pieces included here:

- a modified github actions script which includes a job to pull microsetta-private-api, install it, and execute the integration tests
- generation of JWT public/private keys
- a means to use new public/private keys at server start
- examples of fake users interacting with the system including login

The test suite provides ways to construct new users which are completely valid from the perspective of authentication, and includes the use of a de-identified user that exists in the test database to assert routing in the state machine.