### PR TITLE
Admin scrub or delete

### DIFF
--- a/microsetta_interface/routes.yaml
+++ b/microsetta_interface/routes.yaml
@@ -787,6 +787,29 @@ paths:
               schema:
                 type: string
 
+  '/admin/account_delete':
+    post:
+      operationId: microsetta_interface.implementation.post_account_delete
+      tags:
+        - Admin
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                account_id:
+                  type: string
+                  nullable: false
+      
+      responses:
+        '200':
+          description: Account successfully deleted, redirect to home
+          content:
+            text/html:
+              schema:
+                type: string
+
   '/admin/interested_users':
     get:
       operationId: microsetta_interface.implementation.get_interested_users

--- a/microsetta_interface/templates/account_details.jinja2
+++ b/microsetta_interface/templates/account_details.jinja2
@@ -404,6 +404,32 @@
             <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
             {% endif %}
         </form>
+        {% if admin_mode %}
+        <br/>
+        <form action="/admin/account_delete" method="post">
+            <div class="card mb-3">
+                <div class="card-header">
+                    *** {{ _('Danger zone') }} ***
+                </div>
+                <div class="card-body">
+                    <p>
+                        {{ _('Delete or scrub the account.') }} 
+                    </p>
+                    <p>
+                        {{ _('If the account has any samples associated, the account and sources will be scrubbed, meaning all free text and identifiable information is removed.') }}
+                    </p>
+                    <p>
+                        {{ _('Otherwise, the account and any sources will be deleted') }}
+                    </p>
+                    <h3>
+                        {{ _('THIS CANNOT BE UNDONE') }}
+                    </h3>
+                    <input type="hidden" id="account_id" name="account_id" value="{{ account.account_id }}"/>
+                    <button type=submit" class="btn btn-danger">{{ _('Delete Account') }}</button>
+                </div>
+            </div>
+        </form>
+        {% endif %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Front end piece for biocore/microsetta-private-api#423. This allows an admin to delete an account, and the option to do so is only available to an admin. 

If the account has any samples associated, the free text for the account, its surveys, and samples are all scrubbed rather than deleted so we can ensure relations are maintained for sample metadata and sequence data. 

An example screenshot is presented.

We are not adding integration tests here as the framework does not allow for the creation of an admin user, as the backend does not expose an endpoint at this time do to so.

![Screen Shot 2022-03-08 at 10 18 16 AM](https://user-images.githubusercontent.com/474290/157300714-d3b9a4df-1bf5-4d9b-bc92-dc88a75dd43b.png)

cc @sejsong @cassidysymons 