### PR TITLE
Adjust workflow for overhaul

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,8 @@ jobs:
         python-version: 3.7 
     
     - name: Install
+      env:
+        BRANCH: ${{ github.ref == 'refs/heads/master-overhaul' && 'master-overhaul' || 'master' }}
       shell: bash -l {0}
       run: |
         conda create --yes -n microsetta-interface python=3.7
@@ -91,7 +93,7 @@ jobs:
         python setup.py compile_catalog
         pip install -e . --no-deps
         
-        git clone https://github.com/biocore/microsetta-private-api.git
+        git clone -b $BRANCH --single-branch https://github.com/biocore/microsetta-private-api.git
         pushd microsetta-private-api
         pgport=${{ job.services.postgres.ports[5432] }}
         sed -i "s/self.port = 5432/self.port = $pgport/" microsetta_private_api/config_manager.py


### PR DESCRIPTION
Adding an environment variable to the job that installs Microsetta Private API. If the pull request or push here on Microsetta Interface is being issued against master-overhaul, the job will clone the master-overhaul branch of Private API. Otherwise, it will clone the master branch of Private API.

This allows all work on the overhaul branch of Interface to successfully run integration tests against the overhaul branch of Private API, while all other branches will continue to run against master.