### PR TITLE
Kit_id and activation code removal change from a fresh fork

### DIFF
--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -1017,7 +1017,7 @@ def get_source(*, account_id=None, source_id=None):
     per_sample = []
     per_source_req = []
     per_source_opt = []
-
+    claim_kit_name_hint = None
     primary = _get_req_survey_templates_by_source_type(
         source_output["source_type"])
     secondary = _get_opt_survey_templates_by_source_type(

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -995,19 +995,6 @@ def top_food_report_pdf(*,
 
 @prerequisite([SOURCE_PREREQS_MET])
 def get_source(*, account_id=None, source_id=None):
-    # Retrieve the account to determine which kit it was created with
-    has_error, account_output, _ = ApiRequest.get(
-        '/accounts/%s' % account_id)
-    if has_error:
-        return account_output
-
-    # Check if there are any unclaimed samples in the kit
-    original_kit, _, kit_status = _get_kit(account_output['kit_name'])
-    if kit_status == 404:
-        claim_kit_name_hint = None
-    else:
-        claim_kit_name_hint = account_output['kit_name']
-
     # Retrieve the source
     has_error, source_output, _ = ApiRequest.get(
         '/accounts/%s/sources/%s' %

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -647,8 +647,6 @@ def get_create_account():
 
 @prerequisite([NEEDS_ACCOUNT])
 def post_create_account(*, body=None):
-    kit_name = body[KIT_NAME_KEY]
-    session[KIT_NAME_KEY] = kit_name
 
     api_json = {
         ACCT_FNAME_KEY: body['first_name'],
@@ -661,9 +659,7 @@ def post_create_account(*, body=None):
             ACCT_ADDR_POST_CODE_KEY: body['post_code'],
             ACCT_ADDR_COUNTRY_CODE_KEY: body['country_code']
         },
-        ACCT_LANG_KEY: body[LANG_KEY],
-        KIT_NAME_KEY: kit_name,
-        ACTIVATION_CODE_KEY: body["code"]
+        ACCT_LANG_KEY: body[LANG_KEY]
     }
 
     has_error, accts_output, _ = \

--- a/microsetta_interface/templates/account_details.jinja2
+++ b/microsetta_interface/templates/account_details.jinja2
@@ -30,23 +30,7 @@
                     post_code: "required",
                     language: "required",
                     {% if CREATE_ACCT %}
-                    kit_name: {
-                        required: "#code:blank",
-                        remote: {
-                            url: "/check_kit_valid"
-                        }
-                    },
-                    code: {
-                        required: "#kit_name:blank",
-                        remote: {
-                            url: "/check_activation_code",
-                            data: {
-                                email: function() {
-                                    return $("#email").val();
-                                }
-                            }
-                        }
-                    },
+
                     {% endif %}
                     // Make sure the form is submitted to the destination defined
                     // in the "action" attribute of the form when valid

--- a/microsetta_interface/templates/account_details.jinja2
+++ b/microsetta_interface/templates/account_details.jinja2
@@ -12,7 +12,7 @@
         $(document).ready(function(){
             let form_name = 'acct_form';
             preventImplicitSubmission(form_name);
-            preclude_whitespace("#kit_name");
+
 
             // Initialize form validation on the registration form.
             // It has the name attribute "registration"
@@ -365,22 +365,7 @@
                 </select>
             </div>
             {% if CREATE_ACCT %}
-            <div class="card mb-3">
-                <div class="card-header">
-                    {{ _('Activation Info') }}
-                </div>
-                <div class="card-body">
-                    <div class="form-group">
-                        <label for="kit_name" name="kit_name_label">{{ _('Kit ID') }}</label>
-                        <input id="kit_name" name="kit_name" class="form-control" type="text"/>
-                    </div>
-                    <div class="text-center">-{{ _('OR') }}-</div>
-                    <div class="form-group">
-                        <label for="code" name="code_label">{{ _('Activation Code') }}</label>
-                        <input id="code" name="code" class="form-control" type="text" placeholder="TMI-XXXXX-XXXXX-XXXXX"/>
-                    </div>
-                </div>
-            </div>
+
             {% endif %}
             {% if CREATE_ACCT %}
             <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>

--- a/microsetta_interface/tests/test_integration.py
+++ b/microsetta_interface/tests/test_integration.py
@@ -242,7 +242,7 @@ class IntegrationTests(unittest.TestCase):
                 "post_code": "f",
                 "language": "en_US",
                 "country_code": "US"
-               }
+                }
 
         resp = self.app.post(url, data=body)
         url = resp.headers['Location']

--- a/microsetta_interface/tests/test_integration.py
+++ b/microsetta_interface/tests/test_integration.py
@@ -241,9 +241,8 @@ class IntegrationTests(unittest.TestCase):
                 "state": "e",
                 "post_code": "f",
                 "language": "en_US",
-                "country_code": "US",
-                "code": "",
-                "kit_name": TEST_KIT_1}
+                "country_code": "US"
+               }
 
         resp = self.app.post(url, data=body)
         url = resp.headers['Location']


### PR DESCRIPTION
This pull contains the changes pertinent to the kit id and activation code removal from signup form. This is from master-overhaul branch of my new fork to biocore/master-overhaul removal