### PR TITLE
Spain Vioscreen Bypass

### DIFF
--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -1318,7 +1318,19 @@ def post_update_sample(*, account_id=None, source_id=None, sample_id=None):
             if answer['survey_template_id'] == VIOSCREEN_ID:
                 has_ffq = True
 
-        if not has_ffq:
+        # Hack to determine if user's country is Spain OR locale is es_ES
+        # If either condition is true, bypass the Vioscreen option
+        spain_user = False
+
+        has_error, account, _ = ApiRequest.get('/accounts/%s' % account_id)
+        if has_error:
+            return account
+
+        country = account[ACCT_ADDR_KEY][ACCT_ADDR_COUNTRY_CODE_KEY]
+        if country == "ES" or session_locale() == "es_ES":
+            spain_user = True
+
+        if not has_ffq and spain_user is False:
             url = '/accounts/%s/sources/%s/samples/%s/after_edit_questionnaire'
             return redirect(url % (account_id, source_id, sample_id))
     return _refresh_state_and_route_to_sink(account_id, source_id)


### PR DESCRIPTION
For THDMI Spain, we made the decision to hide the Vioscreen option to minimize confusion, as it won't work in Spain. This behavior is working correctly on the Source page, as the Vioscreen FFQ button is not displayed for Spanish users. However, during testing, we missed the post-sample page that encourages the user to take the Vioscreen FFQ.

This change mirrors the logic of determining a Spanish user (either their account country or locale matching Spain) and, if it does, bypasses the redirect to the page suggesting they take the Vioscreen FFQ.