### PR TITLE
Adjust date validation for i18n issues

### DIFF
--- a/microsetta_interface/templates/sample.jinja2
+++ b/microsetta_interface/templates/sample.jinja2
@@ -16,22 +16,6 @@
     <script>
 
         $(document).ready(function(){
-            $("form").submit(function(e) {
-                var date = $("#sample_date").val()
-                date = new Date(date);
-                var lower_limit = new Date();
-                lower_limit .setFullYear( lower_limit.getFullYear() - 10 );
-                var upper_limit  = new Date();
-                upper_limit .setMonth(upper_limit.getMonth() + 1);
-                if(date < lower_limit) {
-                    alert("{{ _('Please select a date within the last 10 years.') }}")
-                    e.preventDefault(e);
-                } else if (date > upper_limit) {
-                    alert("{{ _('Please select a date within the next 30 days.') }}")
-                    e.preventDefault(e);
-                }
-            });
-            
             let form_name = 'sample_form';
             preventImplicitSubmission(form_name);
 
@@ -85,6 +69,34 @@
                 //expected localized date format matching the datepicker settings.
             }, "{{ _('Required Format: MM/DD/YYYY') }}");
 
+            $.validator.addMethod("dateInPast", function(value, element)
+            {
+                let check;
+                let date = new Date($("#sample_date_normalized").val());
+                var lower_limit = new Date();
+                lower_limit.setFullYear(lower_limit.getFullYear() - 10);
+                if(date < lower_limit) {
+                    check = false;
+                } else {
+                    check = true;
+                }
+                return this.optional(element) || check;
+            }, "{{ _('Please select a date within the last 10 years.') }}");
+
+            $.validator.addMethod("dateInFuture", function(value, element)
+            {
+                let check;
+                let date = new Date($("#sample_date_normalized").val());
+                var upper_limit  = new Date();
+                upper_limit.setMonth(upper_limit.getMonth() + 1);
+                if(date > upper_limit) {
+                    check = false;
+                } else {
+                    check = true;
+                }
+                return this.optional(element) || check;
+            }, "{{ _('Please select a date within the next 30 days.') }}");
+
             $("#sample_date").datepicker(datepicker_args)
 
             $( "#sample_time" ).timepicker({
@@ -120,7 +132,9 @@
                     // on the right side
                     sample_date: {
                         required: true,
-                        monthDayYear: true
+                        monthDayYear: true,
+                        dateInPast: true,
+                        dateInFuture: true
                     },
                     sample_time: "required",
                     {% if not is_environmental %}


### PR DESCRIPTION
Date validation on sample details was not using the hidden normalized date field, so ambiguous dates such as October 12 (10/12 vs. 12/10 depending on locale) were running afoul of the rule about being more than 30 days in the future. Moved the validation further down the chain so it can use the normalized value and function correctly.