### PR TITLE
Changed requested by Japanese collaborators

### DIFF
--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -2016,7 +2016,8 @@ def get_campaign_edit(campaign_id=None):
         campaign_info['language_key_alt'] = None
         campaign_info['title_alt'] = None
         campaign_info['instructions_alt'] = None
-        campaign_info['send_thdmi_confirmaion'] = None
+        campaign_info['send_thdmi_confirmation'] = None
+        campaign_info['force_primary_language'] = None
 
     permitted_countries = []
     if campaign_info['permitted_countries'] is not None:
@@ -2057,6 +2058,7 @@ def post_campaign_edit(body):
     title_alt = request.form['title_alt']
     instructions_alt = request.form['instructions_alt']
     send_thdmi_confirmation = request.form['send_thdmi_confirmation']
+    force_primary_language = request.form['force_primary_language']
 
     if 'campaign_id' in request.form:
         do_return, campaign_info, _ = ApiRequest.put(
@@ -2072,7 +2074,8 @@ def post_campaign_edit(body):
                 "title_alt": title_alt,
                 "instructions_alt": instructions_alt,
                 "extension": extension,
-                "send_thdmi_confirmation": send_thdmi_confirmation
+                "send_thdmi_confirmation": send_thdmi_confirmation,
+                "force_primary_language": force_primary_language
             }
         )
     else:
@@ -2092,7 +2095,8 @@ def post_campaign_edit(body):
                 "title_alt": title_alt,
                 "instructions_alt": instructions_alt,
                 "extension": extension,
-                "send_thdmi_confirmation": send_thdmi_confirmation
+                "send_thdmi_confirmation": send_thdmi_confirmation,
+                "force_primary_language": force_primary_language
             }
         )
 
@@ -2131,12 +2135,21 @@ def get_submit_interest(campaign_id=None, source=None):
             if user_lang == campaign_info['language_key_alt']:
                 show_alt_info = True
 
-    return _render_with_defaults('submit_interest.jinja2',
-                                 valid_campaign=valid_campaign,
-                                 campaign_id=campaign_id,
-                                 source=source,
-                                 campaign_info=campaign_info,
-                                 show_alt_info=show_alt_info)
+    if campaign_info['force_primary_language']:
+        with flask_babel.force_locale(campaign_info['language_key']):
+            return _render_with_defaults('submit_interest.jinja2',
+                                         valid_campaign=valid_campaign,
+                                         campaign_id=campaign_id,
+                                         source=source,
+                                         campaign_info=campaign_info,
+                                         show_alt_info=show_alt_info)
+    else:
+        return _render_with_defaults('submit_interest.jinja2',
+                                     valid_campaign=valid_campaign,
+                                     campaign_id=campaign_id,
+                                     source=source,
+                                     campaign_info=campaign_info,
+                                     show_alt_info=show_alt_info)
 
 
 def post_submit_interest(body):
@@ -2184,9 +2197,16 @@ def post_submit_interest(body):
         if user_lang == campaign_info['language_key_alt']:
             show_alt_info = True
 
-        return _render_with_defaults('submit_interest_confirm.jinja2',
-                                     campaign_info=campaign_info,
-                                     show_alt_info=show_alt_info)
+        if campaign_info['force_primary_language']:
+            with flask_babel.force_locale(campaign_info['language_key']):
+                return _render_with_defaults('submit_interest_confirm.jinja2',
+                                             campaign_info=campaign_info,
+                                             show_alt_info=show_alt_info)
+        else:
+            return _render_with_defaults('submit_interest_confirm.jinja2',
+                                         campaign_info=campaign_info,
+                                         show_alt_info=show_alt_info)
+
     else:
         e_msg = gettext("Sorry, there was a problem saving your information.")
         raise Exception(e_msg)

--- a/microsetta_interface/templates/admin_campaign_edit.jinja2
+++ b/microsetta_interface/templates/admin_campaign_edit.jinja2
@@ -120,6 +120,15 @@
                 </td>
             </tr>
             <tr>
+                <td><label for="force_primary_language">{{ _('Force Primary Language on Form') }}:</label></td>
+                <td>
+                    <select name="force_primary_language" id="force_primary_language">
+                        <option value="False"{% if campaign_info.force_primary_language is false %}selected{% endif %}>No</option>
+                        <option value="True" {% if campaign_info.force_primary_language is true %}selected{% endif %}>Yes</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
                 <td colspan="2" align="center"><input type="submit" value="{{ _('Submit') }}"></td>
             </tr>
         </table>

--- a/microsetta_interface/templates/submit_interest.jinja2
+++ b/microsetta_interface/templates/submit_interest.jinja2
@@ -76,6 +76,10 @@ $(document).ready(function(){
             } else if (selected_country == "JP") {
                 $("#form_group_address_3").show();
                 $("#form_group_city, #form_group_state").hide();
+                $("#phone").rules( "remove" );
+                $("#phone").rules( "add", {
+                    required: true
+                });
                 $("#city").rules("remove");
                 $("#state").rules("remove");
             } else {
@@ -176,8 +180,7 @@ $(document).ready(function(){
                     email: true
                 },
                 phone: {
-                    required: true,
-                    phoneUS: true
+                    required: true
                 },
                 country: {
                     required: true,

--- a/microsetta_interface/translations/ja_JP/LC_MESSAGES/messages.po
+++ b/microsetta_interface/translations/ja_JP/LC_MESSAGES/messages.po
@@ -2916,7 +2916,7 @@ msgstr "あなたの姓を入力してください。"
 
 #: templates/submit_interest.jinja2:224
 msgid "Please enter a valid email address."
-msgstr "有効なメールアドレスを入力してください。"
+msgstr "メールアドレスを入力してください。"
 
 #: templates/submit_interest.jinja2:227
 msgid "Please select your country."
@@ -2933,7 +2933,7 @@ msgstr ""
 
 #: templates/submit_interest.jinja2:236 templates/submit_interest.jinja2:592
 msgid "Please agree to receiving communications from us."
-msgstr "マイクロゼッタからの連絡を受信することに同意してください。"
+msgstr "THDMIジャパンプロジェクトからのメールが受信出来る環境に設定をお願いします。"
 
 #: templates/submit_interest.jinja2:297
 msgid ""
@@ -3011,7 +3011,7 @@ msgstr "選択"
 
 #: templates/submit_interest.jinja2:552
 msgid "Please fill in the address you would like your kit delivered to. Example:"
-msgstr "採便キットのお届け先のご住所をご記入ください。記入例："
+msgstr "採便キットのお届け先のご住所をご記入ください。"
 
 #: templates/submit_interest.jinja2:553
 msgid "9500 Gilman Dr.<br />San Diego, CA 92093"
@@ -3034,9 +3034,7 @@ msgid ""
 "and this will not change my consent to receive sample status updates directly "
 "from the TMI database. "
 msgstr ""
-"登録後、研究状況、参加申し込みに必要な手順、アンケート調査に関する手続きの連絡"
-"をメールマガジンで受け取ることに同意します。私は、メールマガジン内に記載された"
-"リンクからいつでもメールマガジンの購読を中止できることに同意します。 "
+"登録後、研究状況、参加申し込みに必要な手順、アンケート調査に関する手続きの連絡を会報で受け取ることに同意します。私は、会報内に記載されたリンクからいつでも会報の購読を中止できることに同意します。また、TMIのデータベースから便サンプルの状況の更新報告を受け取ることに同意します。"
 
 #: templates/submit_interest.jinja2:596
 msgid "Previous"


### PR DESCRIPTION
This PR corresponds to https://github.com/biocore/microsetta-private-api/pull/482 and includes the interface changes necessary to support that.

In addition:
1) Removes US phone validation as a default rule on submit_interest.jinja2. Now, phone is required, but it will only validate format when a user selects United States as the country. In the future, per-country phone validation would be ideal, but since it's the tertiary mode of contact in this context, it's unimportant.
2) Updates a few strings in messages.po for ja_JP