### PR TITLE
Python 3.6 -> 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: set up python 3.6
+    - name: set up python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: lint it
       run: python -m pip install --upgrade pip
     - name: lint


### PR DESCRIPTION
For some reason, lint was using Python 3.6, which it appears is no longer available as of this morning? Updating to 3.7.