### PR TITLE
Disable Japanese Locale

### DIFF
--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -926,7 +926,7 @@ def get_authrocket_callback(token=None, redirect_uri=None):
         # NB: Disabling Japanese for the initial relaunch period until the
         # Tokyo Tech team can review finalized translations
         if primary["language"] == "ja_JP":
-            session[LANG_KEY] = "en_US"
+            session[LANG_KEY] = EN_US_KEY
         else:
             session[LANG_KEY] = primary["language"]
     else:

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -923,7 +923,12 @@ def get_authrocket_callback(token=None, redirect_uri=None):
             "account_id": primary['account_id'],
             "email": primary['email']
         }
-        session[LANG_KEY] = primary["language"]
+        # NB: Disabling Japanese for the initial relaunch period until the
+        # Tokyo Tech team can review finalized translations
+        if primary["language"] == "ja_JP":
+            session[LANG_KEY] = "en_US"
+        else:
+            session[LANG_KEY] = primary["language"]
     else:
         session[ADMIN_MODE_KEY] = False
         session[LOGIN_INFO_KEY] = {

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -925,7 +925,7 @@ def get_authrocket_callback(token=None, redirect_uri=None):
         }
         # NB: Disabling Japanese for the initial relaunch period until the
         # Tokyo Tech team can review finalized translations
-        if primary["language"] == "ja_JP":
+        if primary["language"] == JA_JP_KEY:
             session[LANG_KEY] = EN_US_KEY
         else:
             session[LANG_KEY] = primary["language"]

--- a/microsetta_interface/model_i18n.py
+++ b/microsetta_interface/model_i18n.py
@@ -14,7 +14,7 @@ LANGUAGES = {
     EN_US_KEY: Lang("en_US", "English"),
     ES_MX_KEY: Lang("es_MX", "Español (México)"),
     ES_ES_KEY: Lang("es_ES", "Español (España)"),
-    JA_JP_KEY: Lang("ja_JP", "日本語")
+    # JA_JP_KEY: Lang("ja_JP", "日本語")
 }
 
 # We need a default full locale when a user's browser only sends a partial


### PR DESCRIPTION
For the initial relaunch period, we're disabling Japanese as timing prevented us from completing a full review with the Tokyo Tech team.