### PR TITLE
Pin connexion[swagger-ui]

### DIFF
--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,4 +1,4 @@
-connexion[swagger-ui]
+connexion[swagger-ui] < 3.0.0
 pyjwt[crypto]
 pytest < 5.3.4
 pytest-cov


### PR DESCRIPTION
Connexion 3.0 was released earlier this month and is breaking workflow. Pinning it to < 3.0.0.