### PR TITLE
Adjust Date Limits for Sample Collection Info

### DIFF
--- a/microsetta_interface/templates/sample.jinja2
+++ b/microsetta_interface/templates/sample.jinja2
@@ -85,33 +85,35 @@
                 //expected localized date format matching the datepicker settings.
             }, "{{ _('Required Format: MM/DD/YYYY') }}");
 
-            $.validator.addMethod("dateInPast", function(value, element)
-            {
-                let check;
-                let date = new Date($("#sample_date_normalized").val());
-                var lower_limit = new Date();
-                lower_limit.setFullYear(lower_limit.getFullYear() - 10);
-                if(date < lower_limit) {
-                    check = false;
-                } else {
-                    check = true;
-                }
-                return this.optional(element) || check;
-            }, "{{ _('Please select a date within the last 10 years.') }}");
+            {% if not admin_mode %}
+                $.validator.addMethod("dateInPast", function(value, element)
+                {
+                    let check;
+                    let date = new Date($("#sample_date_normalized").val());
+                    var lower_limit = new Date();
+                    lower_limit.setFullYear(lower_limit.getFullYear() - 1);
+                    if(date < lower_limit) {
+                        check = false;
+                    } else {
+                        check = true;
+                    }
+                    return this.optional(element) || check;
+                }, "{{ _('Please select a date within the last year.') }}");
 
-            $.validator.addMethod("dateInFuture", function(value, element)
-            {
-                let check;
-                let date = new Date($("#sample_date_normalized").val());
-                var upper_limit  = new Date();
-                upper_limit.setMonth(upper_limit.getMonth() + 1);
-                if(date > upper_limit) {
-                    check = false;
-                } else {
-                    check = true;
-                }
-                return this.optional(element) || check;
-            }, "{{ _('Please select a date within the next 30 days.') }}");
+                $.validator.addMethod("dateInFuture", function(value, element)
+                {
+                    let check;
+                    let date = new Date($("#sample_date_normalized").val());
+                    var upper_limit  = new Date();
+                    upper_limit.setMonth(upper_limit.getMonth() + 1);
+                    if(date > upper_limit) {
+                        check = false;
+                    } else {
+                        check = true;
+                    }
+                    return this.optional(element) || check;
+                }, "{{ _('Please select a date within the next 30 days.') }}");
+            {% endif %}
 
             $("#sample_date").datepicker(datepicker_args)
 


### PR DESCRIPTION
Two adjustments:
* Change the back-dating limit from 10 years to 1 year
* Allow admin accounts to bypass the limits