### PR TITLE
added new sample statuses

### DIFF
--- a/microsetta_interface/templates/reports.jinja2
+++ b/microsetta_interface/templates/reports.jinja2
@@ -90,9 +90,23 @@
                 <div class="barcode-col barcode-text">
                     {{ sample.sample_barcode }}
                 </div>
-                <div class="barcode-col barcode-col-end" id="btn-view-{{ sample.sample_id }}">
-                    <span class="sample-label">{{ _('Not Received Yet') }}</span>
-                </div>
+                {% if sample.latest_scan_timestamp is none %}
+                    <div class="barcode-col barcode-col-end" id="btn-view-{{ sample.sample_id }}">
+                        <span class="sample-label">{{ _('Not Yet Received ') }} </span>
+                    </div>
+                {% elif sample.last_update is none %}
+                    <div class="barcode-col barcode-col-end" id="btn-view-{{ sample.sample_id }}">
+                        <span class="sample-label">{{ _('Sample Received - Information Needed ') }} </span>
+                    </div>
+                {% elif sample.latest_scan_timestamp > sample.last_update %}
+                    <div class="barcode-col barcode-col-end" id="btn-view-{{ sample.sample_id }}">
+                        <span class="sample-label">{{ _('Sample Received - Information Still Needed ') }} </span>
+                    </div>
+                {% else %}
+                    <div class="barcode-col barcode-col-end" id="btn-view-{{ sample.sample_id }}">
+                        <span class="sample-label">{{ _('Sample Received - Update Pending ') }} </span>
+                    </div>
+                {% endif %}
             </div>
             {% endfor %}
             {% for er in external_reports_kit %}

--- a/microsetta_interface/templates/reports.jinja2
+++ b/microsetta_interface/templates/reports.jinja2
@@ -90,17 +90,13 @@
                 <div class="barcode-col barcode-text">
                     {{ sample.sample_barcode }}
                 </div>
-                {% if sample.latest_scan_timestamp is none %}
+                {% if sample.sample_latest_scan_timestamp is none %}
                     <div class="barcode-col barcode-col-end" id="btn-view-{{ sample.sample_id }}">
                         <span class="sample-label">{{ _('Not Yet Received ') }} </span>
                     </div>
-                {% elif sample.last_update is none %}
+                {% elif sample.sample_latest_sample_information_update is none or sample.sample_latest_scan_timestamp > sample.sample_latest_sample_information_update %}
                     <div class="barcode-col barcode-col-end" id="btn-view-{{ sample.sample_id }}">
                         <span class="sample-label">{{ _('Sample Received - Information Needed ') }} </span>
-                    </div>
-                {% elif sample.latest_scan_timestamp > sample.last_update %}
-                    <div class="barcode-col barcode-col-end" id="btn-view-{{ sample.sample_id }}">
-                        <span class="sample-label">{{ _('Sample Received - Information Still Needed ') }} </span>
                     </div>
                 {% else %}
                     <div class="barcode-col barcode-col-end" id="btn-view-{{ sample.sample_id }}">


### PR DESCRIPTION
Added last_update column to ag_kit_barcodes table to microsetta-private-api, [PR here](https://github.com/biocore/microsetta-private-api/pull/558). This will enable a more descriptive sample status on the 'My Reports' tab.

The new sample statuses are as followed.

- Not Yet Received (Sample has not be scanned yet)
- Sample Received - Report Pending (Sample has been scanned and has the necessary information, now just awaiting Report generation)
- Sample Received - Update Pending (Sample has been updated with new information but has not been scanned yet)
- Sample Received - Information Needed (Sample has been scanned but lacks necessary information)
- Sample Received - Information Still Needed (Sample has been updated with new information and has been scanned but it still lacks necessary information)