### PR TITLE
Update pip and conda requirements to fix error on install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: set up python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: lint it
@@ -22,7 +22,7 @@ jobs:
         pip install -q flake8
         flake8 microsetta_interface
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
 
@@ -47,7 +47,7 @@ jobs:
         conda activate test-microsetta-interface
         pytest
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
       
     # Service containers to run with `runner-job`
     services:

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -1,7 +1,7 @@
-flake8==5.0.4
-flask==2.2.5
-natsort==8.4.0
-pycryptodome==3.15.0
-babel==2.14.0
+flake8
+flask < 3.0.0
+natsort
+pycryptodome
+redis-py
 flask-babel==2.0.0
-pandas==1.3.5
+pandas

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -1,9 +1,7 @@
-flake8
-flask < 3.0.0
-natsort
-pycryptodome
-redis-py
-redis
-pytest
-flask-babel=2.0.0
-pandas
+flake8==5.0.4
+flask==2.2.5
+natsort==8.4.0
+pycryptodome==3.15.0
+babel==2.14.0
+flask-babel==2.0.0
+pandas==1.3.5

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -8,3 +8,4 @@ coveralls
 pycountry
 python-dateutil
 redis==4.6.0
+redis-server==6.0.9

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,10 +1,10 @@
-openapi-spec-validator==0.2.9
+openapi-spec-validator < 0.2.10
 swagger-ui-bundle==0.0.9
-connexion[swagger-ui]==2.7.0
-pyjwt[crypto]==2.1.0
-pytest==5.3.3
-pytest-cov==4.1.0
-coveralls==3.3.1
-pycountry==22.3.5
-python-dateutil==2.9.0
+connexion[swagger-ui] < 2.7.1
+pyjwt[crypto] < 2.2.0
+pytest < 5.3.4
+pytest-cov
+coveralls
+pycountry
+python-dateutil
 redis==4.6.0

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,9 +1,10 @@
-openapi-spec-validator < 0.2.10
+openapi-spec-validator==0.2.9
 swagger-ui-bundle==0.0.9
-connexion[swagger-ui] < 2.7.1
-pyjwt[crypto] < 2.2.0
-pytest < 5.3.4
-pytest-cov
-coveralls
-pycountry
-python-dateutil
+connexion[swagger-ui]==2.7.0
+pyjwt[crypto]==2.1.0
+pytest==5.3.3
+pytest-cov==4.1.0
+coveralls==3.3.1
+pycountry==22.3.5
+python-dateutil==2.9.0
+redis==4.6.0


### PR DESCRIPTION
# Fix error that occurs while running the microsetta-interface server after a fresh install of the repo

## Reproduce the error by installing microsetta-interface following the README.md install instructions

After the microsetta-interface is installed in editable mode

    $ pip install -e .

Run the Test server

    $ python microsetta_interface/server.py

### Error message occurs after running microsetta-interface server command

> Traceback (most recent call last):
  File "microsetta_interface/server.py", line 12, in <module>
    from microsetta_interface.implementation import session_locale
  File "/Users/lmerchant/CMI_Work/repos_duplicate/microsetta-interface/microsetta_interface/implementation.py", line 32, in <module>
    from microsetta_interface.redis_cache import RedisCache
  File "/Users/lmerchant/CMI_Work/repos_duplicate/microsetta-interface/microsetta_interface/redis_cache.py", line 2, in <module>
    import redis
  File "/usr/local/anaconda3/envs/microsetta-interface/lib/python3.7/site-packages/redis/__init__.py", line 3, in <module>
    from redis import asyncio  # noqa
  File "/usr/local/anaconda3/envs/microsetta-interface/lib/python3.7/site-packages/redis/asyncio/__init__.py", line 1, in <module>
    from redis.asyncio.client import Redis, StrictRedis
  File "/usr/local/anaconda3/envs/microsetta-interface/lib/python3.7/site-packages/redis/asyncio/client.py", line 27, in <module>
    from redis._parsers.helpers import (
  File "/usr/local/anaconda3/envs/microsetta-interface/lib/python3.7/site-packages/redis/_parsers/__init__.py", line 1, in <module>
    from .base import BaseParser, _AsyncRESPBase
  File "/usr/local/anaconda3/envs/microsetta-interface/lib/python3.7/site-packages/redis/_parsers/base.py", line 9, in <module>
    from async_timeout import timeout as async_timeout
  File "/usr/local/anaconda3/envs/microsetta-interface/lib/python3.7/site-packages/async_timeout/__init__.py", line 5, in <module>
    from typing import Optional, Type, final
ImportError: cannot import name 'final' from 'typing' (/usr/local/anaconda3/envs/microsetta-interface/lib/python3.7/typing.py)


### Look at ImportError about 'typing'

    ImportError: cannot import name 'final' from 'typing' (/usr/local/anaconda3/envs/microsetta-interface/lib/python3.7/typing.py)

The error encountered occurs because the final feature was introduced in Python 3.8 and is not available in Python 3.7.

The error occurs in async_timeout

Get the version of async_timeout
    $ pip show async-timeout

> Name: async-timeout <br>
> Version: 5.0.0 <br>
> Required-by: redis <br>

Get the version of redis
    $ pip show redis

> Name: redis <br>
> Version: 5.0.7 <br>

Go to pypi page for redis: https://pypi.org/project/redis/

> **Note: ** redis-py 5.0 will be the last version of redis-py to support Python 3.7, as it has reached end of life. redis-py 5.1 will support Python 3.8+.

Try installing redis-py 5.0 and not 5.0.7 and run start server command

    $ pip uninstall redis
    $ pip install redis==5.0.0

Still get the errors

## Fix for no errors

Install redis 4.6.0

    $ pip uninstall redis
    $ pip install redis==4.6.0

Run the Test server

    $ python microsetta_interface/server.py

Now there is no error, and the server starts

### Find the versions of packages to update the original pip requirements

List the updated pip installed packages

    $ pip list

Include redis==4.6.0 in pip requirements since it is not found with conda (get a PackagesNotFoundError)

> openapi-spec-validator==0.2.9 <br>
> swagger-ui-bundle==0.0.9 <br>
> connexion[swagger-ui]==2.7.0 <br>
> pyjwt[crypto]==2.1.0 <br>
> pytest==5.3.3 <br>
> pytest-cov==4.1.0 <br>
> coveralls==3.3.1 <br>
> pycountry==22.3.5 <br>
> python-dateutil==2.9.0 <br>
> redis==4.6.0

Save these packages and versions to the file pip_requirements_updated.txt

### List the updated conda installed packages

    $ conda list

Find the versions of packages to update the previous conda requirements. Note redis is removed from the conda requirements

> flake8==5.0.4
> flask==2.2.5
> natsort==8.4.0
> pycryptodome==3.15.0
> pytest==5.3.3
> flask-babel=2.0.0
> pandas==1.3.5

Save these packages and versions to file conda_requirements_updated.txt

## Delete the conda environment microsetta-interface and create it using the updated requirements

    $ conda deactivate
    $ conda remove -n microsetta-interface --all

    $ conda create --yes -n microsetta-interface python=3.7
    $ conda install --yes -n microsetta-interface --file ci/conda_requirements_updated.txt
    $ conda activate microsetta-interface

Install updated pip requirements

    $ pip install -r ci/pip_requirements_updated.txt

Then install the microsetta-interface in editable mode:

    $ pip install -e .

Get an error after this command

ModuleNotFoundError: No module named 'babel'

Fix is to install babel

    $ conda install babel

Get the version of babel with conda list

> babel==2.14.0

Add babel==2.14.0 to conda_requirements_updated.txt

Update flask-babel=2.0.0 in conda_requirements_updated.txt to flask-babel==2.0.0

Remove pytest==5.3.3 from conda_requirements_updated.txt since it is already in pip_requirements_updated.txt

## Delete the conda environment and recreate it using the updated requirements

Follow the steps above for deleting the environment, installing packages, and installing code

Run the Test server

    $ python microsetta_interface/server.py

Now it works

Running pytest also works

## Replace old requirements content with the updated content

Copy contents of updated requirements into their respective files: pip_requirements.txt and conda_requirements.txt

