### PR TITLE
Adjust Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: set up python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: lint it


### PR DESCRIPTION
The change from "ubuntu-latest" to "ubuntu-22.04" was working two days ago but is now failing for the lint check. Looking at microsetta-private-api's workflow, it uses action/setup-python@v2 rather than @v1, switching to that.