### PR TITLE
Add run command to install Redis server in the GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,10 @@ jobs:
 
     - name: Setup for conda
       uses: conda-incubator/setup-miniconda@v2
-      with:        
+      with:
         auto-update-conda: true
         python-version: 3.7
-      
+
     - name: Install
       shell: bash -l {0}
       run: |
@@ -39,7 +39,7 @@ jobs:
         conda activate test-microsetta-interface
         conda install --yes --file ci/conda_requirements.txt
         pip install -r ci/pip_requirements.txt
-        pip install -e . --no-deps 
+        pip install -e . --no-deps
 
     - name: Test
       shell: bash -l {0}
@@ -48,7 +48,7 @@ jobs:
         pytest
   integration:
     runs-on: ubuntu-22.04
-      
+
     # Service containers to run with `runner-job`
     services:
       # Label used to access the service container
@@ -56,10 +56,10 @@ jobs:
         # Docker Hub image
         image: postgres:13.4
         env:
-          POSTGRES_DB: ag_test  
-          POSTGRES_USER: postgres  
+          POSTGRES_DB: ag_test
+          POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          
+
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
@@ -77,10 +77,15 @@ jobs:
 
     - name: Setup for conda
       uses: conda-incubator/setup-miniconda@v2
-      with:        
+      with:
         auto-update-conda: true
-        python-version: 3.7 
-    
+        python-version: 3.7
+
+    - name: Install Redis
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y redis-server
+
     - name: Install
       env:
         BRANCH: ${{ github.base_ref == 'master-overhaul' && 'master-overhaul' || 'master' }}
@@ -93,21 +98,21 @@ jobs:
         pip install -r ci/pip_requirements.txt
         python setup.py compile_catalog
         pip install -e . --no-deps
-        
+
         git clone -b $BRANCH --single-branch https://github.com/biocore/microsetta-private-api.git
         pushd microsetta-private-api
         pgport=${{ job.services.postgres.ports[5432] }}
         sed -i "s/self.port = 5432/self.port = $pgport/" microsetta_private_api/config_manager.py
-        
-        # PGPASSWORD is read by pg_restore, which is called by the build_db process. 
+
+        # PGPASSWORD is read by pg_restore, which is called by the build_db process.
         export PGPASSWORD=postgres
-        
+
         conda create --yes -n microsetta-private-api python=3.7
         conda activate microsetta-private-api
         conda install --yes --file ci/conda_requirements.txt
         pip install -r ci/pip_requirements.txt
-        pip install -e . --no-deps 
-        
+        pip install -e . --no-deps
+
         # establish database state
         python microsetta_private_api/LEGACY/build_db.py
         popd
@@ -125,7 +130,7 @@ jobs:
         redis-server --daemonize yes
         source keys_for_testing.sh
         python microsetta_interface/tests/test_integration.py 2> >(tee -a stderr.log >&2)
-        
+
         # make sure we did not skip tests, which would indicate a failure in
         # the harness. this test will produce an exit status of 1 if the
         # test suite reports skipped tests


### PR DESCRIPTION
Before 2024, Redis server was installed on GitHub Ubuntu runners. But the latest Ubuntu image used in the GitHub actions file main.yml no longer has Redis server installed. Pip and Conda can not install Redis server because it's not a python package.

Because redis-server is not installed by pip or conda, and the latest Ubuntu GitHub runner image does not have redis-server installed, the command "redis-server --daemonize yes" in the integration section of main.yml fails. This leads to integration tests failing. Adding a run command to install redis-server to main.yml will install redis-server to Ubuntu.