### PR TITLE
Update pip and conda requirements for python server to work in conda environ

### DIFF
--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -1,7 +1,7 @@
-flake8==5.0.4
-flask==2.2.5
-natsort==8.4.0
-pycryptodome==3.15.0
-babel==2.14.0
+flake8
+flask < 3.0.0
+natsort
+pycryptodome
+redis-py
 flask-babel==2.0.0
-pandas==1.3.5
+pandas

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -2,6 +2,5 @@ flake8
 flask < 3.0.0
 natsort
 pycryptodome
-redis-py
 flask-babel==2.0.0
 pandas

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -1,9 +1,7 @@
-flake8
-flask < 3.0.0
-natsort
-pycryptodome
-redis-py
-redis
-pytest
-flask-babel=2.0.0
-pandas
+flake8==5.0.4
+flask==2.2.5
+natsort==8.4.0
+pycryptodome==3.15.0
+babel==2.14.0
+flask-babel==2.0.0
+pandas==1.3.5

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -8,3 +8,4 @@ coveralls
 pycountry
 python-dateutil
 redis==4.6.0
+redis-server==6.0.9

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -7,5 +7,4 @@ pytest-cov
 coveralls
 pycountry
 python-dateutil
-redis==4.6.0
-redis-server==6.0.9
+redis

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,10 +1,10 @@
-openapi-spec-validator==0.2.9
+openapi-spec-validator < 0.2.10
 swagger-ui-bundle==0.0.9
-connexion[swagger-ui]==2.7.0
-pyjwt[crypto]==2.1.0
-pytest==5.3.3
-pytest-cov==4.1.0
-coveralls==3.3.1
-pycountry==22.3.5
-python-dateutil==2.9.0
+connexion[swagger-ui] < 2.7.1
+pyjwt[crypto] < 2.2.0
+pytest < 5.3.4
+pytest-cov
+coveralls
+pycountry
+python-dateutil
 redis==4.6.0

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,9 +1,10 @@
-openapi-spec-validator < 0.2.10
+openapi-spec-validator==0.2.9
 swagger-ui-bundle==0.0.9
-connexion[swagger-ui] < 2.7.1
-pyjwt[crypto] < 2.2.0
-pytest < 5.3.4
-pytest-cov
-coveralls
-pycountry
-python-dateutil
+connexion[swagger-ui]==2.7.0
+pyjwt[crypto]==2.1.0
+pytest==5.3.3
+pytest-cov==4.1.0
+coveralls==3.3.1
+pycountry==22.3.5
+python-dateutil==2.9.0
+redis==4.6.0


### PR DESCRIPTION
    Remove redis-py and redis from coda requirements and add redis
    to pip_requirements.txt. It's not possible to install redis-server with
    pip or conda since it's not a python package. So the only install for
    redis is the client. Pip has a more current redis version than conda.
    With conda, redis needs to be < 5.0 and for pip, redis is 5.0.8. Having
    redis only in pip_requirements also follows the setup for
    microsetta-private-api where redis is in pip_requirements.txt and
    not in conda_requirements.txt.