### PR TITLE
SBI Pre-launch Adjustments

### DIFF
--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -2518,14 +2518,14 @@ def get_update_sample(*, account_id=None, source_id=None, sample_id=None):
         if sslwd is None:
             sslwd = ""
         sample_output['barcode_meta']['sample_site_last_washed_date'] = sslwd
-        
+
         sslwt = sample_output['barcode_meta'].get(
             'sample_site_last_washed_time'
         )
         if sslwt is None:
             sslwt = ""
         sample_output['barcode_meta']['sample_site_last_washed_time'] = sslwt
-        
+
         sslwp = sample_output['barcode_meta'].get(
             'sample_site_last_washed_product'
         )

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -2512,11 +2512,13 @@ def get_update_sample(*, account_id=None, source_id=None, sample_id=None):
 
     if sample_output['sample_site'] == "Cheek":
         # Format date and time to be JavaScript-friendly
-        if sample_output['barcode_meta']['sample_site_last_washed_date']\
-            is None:
+        if sample_output['barcode_meta'][
+            'sample_site_last_washed_date'
+        ] is None:
             sample_output['barcode_meta']['sample_site_last_washed_date'] = ""
-        if sample_output['barcode_meta']['sample_site_last_washed_time']\
-            is None:
+        if sample_output['barcode_meta'][
+            'sample_site_last_washed_time'
+        ] is None:
             sample_output['barcode_meta']['sample_site_last_washed_time'] = ""
 
     profile_has_samples = _check_if_source_has_samples(account_id, source_id)

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -1991,7 +1991,8 @@ def get_source(*, account_id=None, source_id=None):
 
 
 @prerequisite([SOURCE_PREREQS_MET, BIOSPECIMEN_PREREQS_MET])
-def get_kits(*, account_id=None, source_id=None, check_survey_date=False):
+def get_kits(*, account_id=None, source_id=None, check_survey_date=False,
+             sample_site=None):
     # Retrieve the account
     has_error, account, _ = ApiRequest.get('/accounts/%s' % account_id)
     if has_error:
@@ -2073,6 +2074,28 @@ def get_kits(*, account_id=None, source_id=None, check_survey_date=False):
 
         prompt_survey_update = prompt_response['prompt']
 
+    # For Cheek samples, we want to display prompt to return to the My Profile
+    # tab and take the Skin Scoring App external survey.
+    # Set a default value of False
+    prompt_skin_app = False
+    if sample_site == "Cheek":
+        # We need to verify that they're eligible for the app, which means
+        # they either already have credentials, or some are availabile. The
+        # business logic is handled in the API, we just need to see if the
+        # survey is available to the source.
+        has_error, surveys_output, _ = ApiRequest.get(
+            '/accounts/%s/sources/%s/survey_templates' % (
+                account_id, source_id
+            )
+        )
+        if has_error:
+            return surveys_output
+
+        for survey in surveys_output:
+            if survey['survey_template_id'] == SKIN_SCORING_APP_ID:
+                prompt_skin_app = True
+                break
+
     need_reconsent_data = check_current_consent(
         account_id, source_id, "data"
     )
@@ -2097,7 +2120,8 @@ def get_kits(*, account_id=None, source_id=None, check_survey_date=False):
         prompt_survey_id=BASIC_INFO_ID,
         need_reconsent_data=need_reconsent_data,
         need_reconsent_biospecimen=need_reconsent_biospecimen,
-        show_update_age=show_update_age
+        show_update_age=show_update_age,
+        prompt_skin_app=prompt_skin_app
     )
 
 
@@ -2582,8 +2606,8 @@ def post_update_sample(*, account_id=None, source_id=None, sample_id=None):
         return sample_output
 
     return redirect(
-        "/accounts/%s/sources/%s/kits?check_survey_date=True" %
-        (account_id, source_id)
+        "/accounts/%s/sources/%s/kits?check_survey_date=True&sample_site=%s" %
+        (account_id, source_id, model['sample_site'])
     )
 
 

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -2486,6 +2486,15 @@ def get_update_sample(*, account_id=None, source_id=None, sample_id=None):
         sample_output['date'] = ""
         sample_output['time'] = ""
 
+    if sample_output['sample_site'] == "Cheek":
+        # Format date and time to be JavaScript-friendly
+        if sample_output['barcode_meta']['sample_site_last_washed_date']\
+            is None:
+            sample_output['barcode_meta']['sample_site_last_washed_date'] = ""
+        if sample_output['barcode_meta']['sample_site_last_washed_time']\
+            is None:
+            sample_output['barcode_meta']['sample_site_last_washed_time'] = ""
+
     profile_has_samples = _check_if_source_has_samples(account_id, source_id)
 
     need_reconsent_data = check_current_consent(

--- a/microsetta_interface/implementation.py
+++ b/microsetta_interface/implementation.py
@@ -2512,14 +2512,27 @@ def get_update_sample(*, account_id=None, source_id=None, sample_id=None):
 
     if sample_output['sample_site'] == "Cheek":
         # Format date and time to be JavaScript-friendly
-        if sample_output['barcode_meta'][
+        sslwd = sample_output['barcode_meta'].get(
             'sample_site_last_washed_date'
-        ] is None:
-            sample_output['barcode_meta']['sample_site_last_washed_date'] = ""
-        if sample_output['barcode_meta'][
+        )
+        if sslwd is None:
+            sslwd = ""
+        sample_output['barcode_meta']['sample_site_last_washed_date'] = sslwd
+        
+        sslwt = sample_output['barcode_meta'].get(
             'sample_site_last_washed_time'
-        ] is None:
-            sample_output['barcode_meta']['sample_site_last_washed_time'] = ""
+        )
+        if sslwt is None:
+            sslwt = ""
+        sample_output['barcode_meta']['sample_site_last_washed_time'] = sslwt
+        
+        sslwp = sample_output['barcode_meta'].get(
+            'sample_site_last_washed_product'
+        )
+        if sslwp is None:
+            sslwp = ""
+        sample_output['barcode_meta'][
+            'sample_site_last_washed_product'] = sslwp
 
     profile_has_samples = _check_if_source_has_samples(account_id, source_id)
 

--- a/microsetta_interface/routes.yaml
+++ b/microsetta_interface/routes.yaml
@@ -427,6 +427,7 @@ paths:
         - $ref: '#/components/parameters/account_id'
         - $ref: '#/components/parameters/source_id'
         - $ref: '#/components/parameters/check_survey_date'
+        - $ref: '#/components/parameters/sample_site'
       responses:
         '200':
           description: Display of kits for a source
@@ -1658,6 +1659,12 @@ components:
       description: T/F flag on whether the Kits page should check user's most recent survey update date
       schema:
         $ref: '#/components/schemas/check_survey_date'
+    sample_site:
+      name: sample_site
+      in: query
+      description: The sample site of the last sample the user edited
+      schema:
+        $ref: '#/components/schemas/sample_site'
     external_report_id:
       name: external_report_id
       in: path
@@ -1728,6 +1735,9 @@ components:
     check_survey_date:
       type: boolean
       example: True
+    sample_site:
+      type: string
+      example: "Cheek"
     external_report_id:
       type: string
       example: "b0b0b0b0-b0b0-b0b0-b0b0-b0b0b0b0b0b0"

--- a/microsetta_interface/static/css/minimal_interface.css
+++ b/microsetta_interface/static/css/minimal_interface.css
@@ -806,6 +806,18 @@ li.active-profile {
     color: var(--tmi-blue);
 }
 
+.alert-kits {
+    background: var(--tmi-orange-bg);
+    border-left: 8px solid var(--tmi-orange);
+    border-radius: 12px;
+    color: var(--tmi-gray-90);
+}
+
+.alert-kits a {
+    color: var(--tmi-blue);
+}
+
+
 .alert-nutrition {
     background: var(--tmi-orange-bg);
     border-left: 8px solid var(--tmi-orange);

--- a/microsetta_interface/templates/kits.jinja2
+++ b/microsetta_interface/templates/kits.jinja2
@@ -199,12 +199,12 @@
     {% else %}
     <div class="container profile-container">
         {% if prompt_survey_update %}
-        <div class="alert alert-primary alert-nutrition mt-4" role="alert">
+        <div class="alert alert-primary alert-kits mt-4" role="alert">
             {{ _('Thank you for logging your sample information. It looks like you haven\'t updated your profile recently. Please review') }} <a href="/accounts/{{account_id}}/sources/{{source_id}}/take_survey?survey_template_id={{prompt_survey_id}}">{{ _('your survey responses') }}</a> {{ _('to ensure they\'re as current and complete as possible.') }}
         </div>
         {% endif %}
         {% if prompt_skin_app %}
-        <div class="alert alert-primary alert-nutrition mt-4" role="alert">
+        <div class="alert alert-primary alert-kits mt-4" role="alert">
             {{ _('You now have access to the Skin Scoring App survey. Please return to the') }} <a href="/accounts/{{account_id}}/sources/{{source_id}}/take_survey?survey_template_id={{prompt_survey_id}}">{{ _('My Profile tab') }}</a> {{ _('to complete it.') }}
         </div>
         {% endif %}

--- a/microsetta_interface/templates/kits.jinja2
+++ b/microsetta_interface/templates/kits.jinja2
@@ -203,6 +203,11 @@
             {{ _('Thank you for logging your sample information. It looks like you haven\'t updated your profile recently. Please review') }} <a href="/accounts/{{account_id}}/sources/{{source_id}}/take_survey?survey_template_id={{prompt_survey_id}}">{{ _('your survey responses') }}</a> {{ _('to ensure they\'re as current and complete as possible.') }}
         </div>
         {% endif %}
+        {% if prompt_skin_app %}
+        <div class="alert alert-primary alert-nutrition mt-4" role="alert">
+            {{ _('You now have access to the Skin Scoring App survey. Please return to the') }} <a href="/accounts/{{account_id}}/sources/{{source_id}}/take_survey?survey_template_id={{prompt_survey_id}}">{{ _('My Profile tab') }}</a> {{ _('to complete it.') }}
+        </div>
+        {% endif %}
         {% if profile_has_samples and (need_reconsent_data or need_reconsent_biospecimen) %}
             <div id="consent_alert" class="alert alert-consent mt-4" role="alert">
                 {{ _('To update your existing samples or contribute new samples, please review the following:') }}<br />

--- a/microsetta_interface/templates/sample.jinja2
+++ b/microsetta_interface/templates/sample.jinja2
@@ -188,7 +188,7 @@
                 timeFormat: 'h:mm p',
                 interval: 30,
                 {% if sample.barcode_meta['sample_site_last_washed_time'] == "" %}
-                defaultTime: 'now',
+                defaultTime: '',
                 {% else %}
                 defaultTime: '{{ sample.barcode_meta['sample_site_last_washed_time'] }}',
                 {% endif %}
@@ -318,7 +318,7 @@
                     </div>
                     <div class="row mt-2 barcode-meta-cheek">
                         <div class="col-12">
-                            <label for="sample_site_last_washed_date" name="sample_site_last_washed_date_label" class="sample-label">{{ _('When did you last wash the area that was swabbed before taking the sample?') }}*</label>
+                            <label for="sample_site_last_washed_date" name="sample_site_last_washed_date_label" class="sample-label">{{ _('When did you last wash the area that was swabbed before taking the sample?') }}</label>
                         </div>
                     </div>
                     <div class="row barcode-meta-cheek">

--- a/microsetta_interface/tests/test_integration.py
+++ b/microsetta_interface/tests/test_integration.py
@@ -416,8 +416,11 @@ class IntegrationTests(unittest.TestCase):
         url = self.redirectURL(resp)
         # Flask's client.get() function doesn't like the query string being
         # attached to the url string. So we'll restructure it.
-        url = url.replace("?check_survey_date=True", "")
-        query_string = {"check_survey_date": "True"}
+        url = url.replace("?check_survey_date=True&sample_site=Stool", "")
+        query_string = {
+            "check_survey_date": "True",
+            "sample_site": "Stool"
+        }
         resp = self.app.get(url, query_string=query_string)
         self.assertPageTitle(resp, 'My Kits')
 


### PR DESCRIPTION
This pull request addresses two issues:
1) It better handles Null/None values being returned for cheek samples' barcode_meta fields.
2) It adds a prompt for users who have just edited a cheek sample to take the Skin Scoring App external survey. Given that we have no insight into whether a user has actually completed the app process (by submitting a selfie), we've opted to display this message whenever a cheek sample is edited and the skin scoring app survey is available to the user.